### PR TITLE
feat: Adding autoscaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ module "dynamodb_table" {
 The [change log](https://github.com/terraform-aws-modules/terraform-aws-dynamodb-table/tree/master/CHANGELOG.md) captures all important release notes.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12.6 |
+| aws | ~> 2.52 |
+
 ## Providers
 
 | Name | Version |
@@ -51,7 +59,7 @@ The [change log](https://github.com/terraform-aws-modules/terraform-aws-dynamodb
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | attributes | List of nested attribute definitions. Only required for hash\_key and range\_key attributes. Each attribute has two properties: name - (Required) The name of the attribute, type - (Required) Attribute type, which must be a scalar type: S, N, or B for (S)tring, (N)umber or (B)inary data | `list(map(string))` | `[]` | no |
 | autoscaling\_defaults | A map of default autoscaling settings | <pre>object(<br>    {<br>      scale_in_cooldown  = number<br>      scale_out_cooldown = number<br>      target_value       = number<br>    }<br>  )</pre> | <pre>{<br>  "scale_in_cooldown": 0,<br>  "scale_out_cooldown": 0,<br>  "target_value": 70<br>}</pre> | no |
 | autoscaling\_indexes | A map of index autoscaling configurations. See example in examples/autoscaling | `map(map(string))` | `{}` | no |
@@ -60,21 +68,21 @@ The [change log](https://github.com/terraform-aws-modules/terraform-aws-dynamodb
 | billing\_mode | Controls how you are billed for read/write throughput and how you manage capacity. The valid values are PROVISIONED or PAY\_PER\_REQUEST | `string` | `"PAY_PER_REQUEST"` | no |
 | create\_table | Controls if DynamoDB table and associated resources are created | `bool` | `true` | no |
 | global\_secondary\_indexes | Describe a GSI for the table; subject to the normal limits on the number of GSIs, projected attributes, etc. | `list(any)` | `[]` | no |
-| hash\_key | The attribute to use as the hash (partition) key. Must also be defined as an attribute | `string` | n/a | yes |
+| hash\_key | The attribute to use as the hash (partition) key. Must also be defined as an attribute | `string` | `null` | no |
 | local\_secondary\_indexes | Describe an LSI on the table; these can only be allocated at creation so you cannot change this definition after you have created the resource. | `list(any)` | `[]` | no |
-| name | Name of the DynamoDB table | `string` | n/a | yes |
+| name | Name of the DynamoDB table | `string` | `null` | no |
 | point\_in\_time\_recovery\_enabled | Whether to enable point-in-time recovery | `bool` | `false` | no |
-| range\_key | The attribute to use as the range (sort) key. Must also be defined as an attribute | `string` | n/a | yes |
-| read\_capacity | The number of read units for this table. If the billing\_mode is PROVISIONED, this field should be greater than 0 | `number` | n/a | yes |
+| range\_key | The attribute to use as the range (sort) key. Must also be defined as an attribute | `string` | `null` | no |
+| read\_capacity | The number of read units for this table. If the billing\_mode is PROVISIONED, this field should be greater than 0 | `number` | `null` | no |
 | server\_side\_encryption\_enabled | Whether or not to enable encryption at rest using an AWS managed KMS customer master key (CMK) | `bool` | `false` | no |
-| server\_side\_encryption\_kms\_key\_arn | The ARN of the CMK that should be used for the AWS KMS encryption. This attribute should only be specified if the key is different from the default DynamoDB CMK, alias/aws/dynamodb. | `string` | n/a | yes |
+| server\_side\_encryption\_kms\_key\_arn | The ARN of the CMK that should be used for the AWS KMS encryption. This attribute should only be specified if the key is different from the default DynamoDB CMK, alias/aws/dynamodb. | `string` | `null` | no |
 | stream\_enabled | Indicates whether Streams are to be enabled (true) or disabled (false). | `bool` | `false` | no |
-| stream\_view\_type | When an item in the table is modified, StreamViewType determines what information is written to the table's stream. Valid values are KEYS\_ONLY, NEW\_IMAGE, OLD\_IMAGE, NEW\_AND\_OLD\_IMAGES. | `string` | n/a | yes |
+| stream\_view\_type | When an item in the table is modified, StreamViewType determines what information is written to the table's stream. Valid values are KEYS\_ONLY, NEW\_IMAGE, OLD\_IMAGE, NEW\_AND\_OLD\_IMAGES. | `string` | `null` | no |
 | tags | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | timeouts | Updated Terraform resource management timeouts | `map(string)` | <pre>{<br>  "create": "10m",<br>  "delete": "10m",<br>  "update": "60m"<br>}</pre> | no |
 | ttl\_attribute\_name | The name of the table attribute to store the TTL timestamp in | `string` | `""` | no |
 | ttl\_enabled | Indicates whether ttl is enabled | `bool` | `false` | no |
-| write\_capacity | The number of write units for this table. If the billing\_mode is PROVISIONED, this field should be greater than 0 | `number` | n/a | yes |
+| write\_capacity | The number of write units for this table. If the billing\_mode is PROVISIONED, this field should be greater than 0 | `number` | `null` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -53,12 +53,10 @@ The [change log](https://github.com/terraform-aws-modules/terraform-aws-dynamodb
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
 | attributes | List of nested attribute definitions. Only required for hash\_key and range\_key attributes. Each attribute has two properties: name - (Required) The name of the attribute, type - (Required) Attribute type, which must be a scalar type: S, N, or B for (S)tring, (N)umber or (B)inary data | `list(map(string))` | `[]` | no |
+| autoscaling\_defaults | A map of default autoscaling settings | <pre>object(<br>    {<br>      scale_in_cooldown  = number<br>      scale_out_cooldown = number<br>      target_value       = number<br>    }<br>  )</pre> | <pre>{<br>  "scale_in_cooldown": 0,<br>  "scale_out_cooldown": 0,<br>  "target_value": 70<br>}</pre> | no |
 | autoscaling\_indexes | A map of index autoscaling configurations. See example in examples/autoscaling | `map(map(string))` | `{}` | no |
-| autoscaling\_read\_max\_capacity | Determines the maximum amount of read capacity the autoscaling is enable to scale. If defined will create an autoscaling structure | `number` | `0` | no |
-| autoscaling\_scale\_in\_cooldown | The amount of time, in seconds, after a scale in activity completes before another scale in activity can start | `number` | `60` | no |
-| autoscaling\_scale\_out\_cooldown | The amount of time, in seconds, after a scale out activity completes before another scale out activity can start | `number` | `60` | no |
-| autoscaling\_target\_value | The target value for the autoscaling metric | `number` | `50` | no |
-| autoscaling\_write\_max\_capacity | Determines the maximum amount of write capacity the autoscaling is enable to scale. If defined will create an autoscaling structure | `number` | `0` | no |
+| autoscaling\_read | A map of read autoscaling settings. `max_capacity` is the only required key. See example in examples/autoscaling | `map(string)` | `{}` | no |
+| autoscaling\_write | A map of write autoscaling settings. `max_capacity` is the only required key. See example in examples/autoscaling | `map(string)` | `{}` | no |
 | billing\_mode | Controls how you are billed for read/write throughput and how you manage capacity. The valid values are PROVISIONED or PAY\_PER\_REQUEST | `string` | `"PAY_PER_REQUEST"` | no |
 | create\_table | Controls if DynamoDB table and associated resources are created | `bool` | `true` | no |
 | global\_secondary\_indexes | Describe a GSI for the table; subject to the normal limits on the number of GSIs, projected attributes, etc. | `list(any)` | `[]` | no |

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ The [change log](https://github.com/terraform-aws-modules/terraform-aws-dynamodb
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
 | attributes | List of nested attribute definitions. Only required for hash\_key and range\_key attributes. Each attribute has two properties: name - (Required) The name of the attribute, type - (Required) Attribute type, which must be a scalar type: S, N, or B for (S)tring, (N)umber or (B)inary data | `list(map(string))` | `[]` | no |
+| autoscaling\_indexes | A map of index autoscaling configurations. See example in examples/autoscaling | `map(map(string))` | `{}` | no |
+| autoscaling\_read\_max\_capacity | Determines the maximum amount of read capacity the autoscaling is enable to scale. If defined will create an autoscaling structure | `number` | `0` | no |
+| autoscaling\_scale\_in\_cooldown | The amount of time, in seconds, after a scale in activity completes before another scale in activity can start | `number` | `60` | no |
+| autoscaling\_scale\_out\_cooldown | The amount of time, in seconds, after a scale out activity completes before another scale out activity can start | `number` | `60` | no |
+| autoscaling\_target\_value | The target value for the autoscaling metric | `number` | `50` | no |
+| autoscaling\_write\_max\_capacity | Determines the maximum amount of write capacity the autoscaling is enable to scale. If defined will create an autoscaling structure | `number` | `0` | no |
 | billing\_mode | Controls how you are billed for read/write throughput and how you manage capacity. The valid values are PROVISIONED or PAY\_PER\_REQUEST | `string` | `"PAY_PER_REQUEST"` | no |
 | create\_table | Controls if DynamoDB table and associated resources are created | `bool` | `true` | no |
 | global\_secondary\_indexes | Describe a GSI for the table; subject to the normal limits on the number of GSIs, projected attributes, etc. | `list(any)` | `[]` | no |

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ module "dynamodb_table" {
 The [change log](https://github.com/terraform-aws-modules/terraform-aws-dynamodb-table/tree/master/CHANGELOG.md) captures all important release notes.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12.6 |
+| aws | ~> 2.52 |
+
 ## Providers
 
 | Name | Version |
@@ -51,7 +58,7 @@ The [change log](https://github.com/terraform-aws-modules/terraform-aws-dynamodb
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | attributes | List of nested attribute definitions. Only required for hash\_key and range\_key attributes. Each attribute has two properties: name - (Required) The name of the attribute, type - (Required) Attribute type, which must be a scalar type: S, N, or B for (S)tring, (N)umber or (B)inary data | `list(map(string))` | `[]` | no |
 | autoscaling\_defaults | A map of default autoscaling settings | `map(string)` | <pre>{<br>  "scale_in_cooldown": 0,<br>  "scale_out_cooldown": 0,<br>  "target_value": 70<br>}</pre> | no |
 | autoscaling\_indexes | A map of index autoscaling configurations. See example in examples/autoscaling | `map(map(string))` | `{}` | no |
@@ -60,21 +67,21 @@ The [change log](https://github.com/terraform-aws-modules/terraform-aws-dynamodb
 | billing\_mode | Controls how you are billed for read/write throughput and how you manage capacity. The valid values are PROVISIONED or PAY\_PER\_REQUEST | `string` | `"PAY_PER_REQUEST"` | no |
 | create\_table | Controls if DynamoDB table and associated resources are created | `bool` | `true` | no |
 | global\_secondary\_indexes | Describe a GSI for the table; subject to the normal limits on the number of GSIs, projected attributes, etc. | `list(any)` | `[]` | no |
-| hash\_key | The attribute to use as the hash (partition) key. Must also be defined as an attribute | `string` | n/a | yes |
+| hash\_key | The attribute to use as the hash (partition) key. Must also be defined as an attribute | `string` | `null` | no |
 | local\_secondary\_indexes | Describe an LSI on the table; these can only be allocated at creation so you cannot change this definition after you have created the resource. | `list(any)` | `[]` | no |
-| name | Name of the DynamoDB table | `string` | n/a | yes |
+| name | Name of the DynamoDB table | `string` | `null` | no |
 | point\_in\_time\_recovery\_enabled | Whether to enable point-in-time recovery | `bool` | `false` | no |
-| range\_key | The attribute to use as the range (sort) key. Must also be defined as an attribute | `string` | n/a | yes |
-| read\_capacity | The number of read units for this table. If the billing\_mode is PROVISIONED, this field should be greater than 0 | `number` | n/a | yes |
+| range\_key | The attribute to use as the range (sort) key. Must also be defined as an attribute | `string` | `null` | no |
+| read\_capacity | The number of read units for this table. If the billing\_mode is PROVISIONED, this field should be greater than 0 | `number` | `null` | no |
 | server\_side\_encryption\_enabled | Whether or not to enable encryption at rest using an AWS managed KMS customer master key (CMK) | `bool` | `false` | no |
-| server\_side\_encryption\_kms\_key\_arn | The ARN of the CMK that should be used for the AWS KMS encryption. This attribute should only be specified if the key is different from the default DynamoDB CMK, alias/aws/dynamodb. | `string` | n/a | yes |
+| server\_side\_encryption\_kms\_key\_arn | The ARN of the CMK that should be used for the AWS KMS encryption. This attribute should only be specified if the key is different from the default DynamoDB CMK, alias/aws/dynamodb. | `string` | `null` | no |
 | stream\_enabled | Indicates whether Streams are to be enabled (true) or disabled (false). | `bool` | `false` | no |
-| stream\_view\_type | When an item in the table is modified, StreamViewType determines what information is written to the table's stream. Valid values are KEYS\_ONLY, NEW\_IMAGE, OLD\_IMAGE, NEW\_AND\_OLD\_IMAGES. | `string` | n/a | yes |
+| stream\_view\_type | When an item in the table is modified, StreamViewType determines what information is written to the table's stream. Valid values are KEYS\_ONLY, NEW\_IMAGE, OLD\_IMAGE, NEW\_AND\_OLD\_IMAGES. | `string` | `null` | no |
 | tags | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | timeouts | Updated Terraform resource management timeouts | `map(string)` | <pre>{<br>  "create": "10m",<br>  "delete": "10m",<br>  "update": "60m"<br>}</pre> | no |
 | ttl\_attribute\_name | The name of the table attribute to store the TTL timestamp in | `string` | `""` | no |
 | ttl\_enabled | Indicates whether ttl is enabled | `bool` | `false` | no |
-| write\_capacity | The number of write units for this table. If the billing\_mode is PROVISIONED, this field should be greater than 0 | `number` | n/a | yes |
+| write\_capacity | The number of write units for this table. If the billing\_mode is PROVISIONED, this field should be greater than 0 | `number` | `null` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -42,14 +42,6 @@ module "dynamodb_table" {
 The [change log](https://github.com/terraform-aws-modules/terraform-aws-dynamodb-table/tree/master/CHANGELOG.md) captures all important release notes.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-
-## Requirements
-
-| Name | Version |
-|------|---------|
-| terraform | ~> 0.12.6 |
-| aws | ~> 2.52 |
-
 ## Providers
 
 | Name | Version |
@@ -59,30 +51,30 @@ The [change log](https://github.com/terraform-aws-modules/terraform-aws-dynamodb
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+|------|-------------|------|---------|:-----:|
 | attributes | List of nested attribute definitions. Only required for hash\_key and range\_key attributes. Each attribute has two properties: name - (Required) The name of the attribute, type - (Required) Attribute type, which must be a scalar type: S, N, or B for (S)tring, (N)umber or (B)inary data | `list(map(string))` | `[]` | no |
-| autoscaling\_defaults | A map of default autoscaling settings | <pre>object(<br>    {<br>      scale_in_cooldown  = number<br>      scale_out_cooldown = number<br>      target_value       = number<br>    }<br>  )</pre> | <pre>{<br>  "scale_in_cooldown": 0,<br>  "scale_out_cooldown": 0,<br>  "target_value": 70<br>}</pre> | no |
+| autoscaling\_defaults | A map of default autoscaling settings | `map(string)` | <pre>{<br>  "scale_in_cooldown": 0,<br>  "scale_out_cooldown": 0,<br>  "target_value": 70<br>}</pre> | no |
 | autoscaling\_indexes | A map of index autoscaling configurations. See example in examples/autoscaling | `map(map(string))` | `{}` | no |
 | autoscaling\_read | A map of read autoscaling settings. `max_capacity` is the only required key. See example in examples/autoscaling | `map(string)` | `{}` | no |
 | autoscaling\_write | A map of write autoscaling settings. `max_capacity` is the only required key. See example in examples/autoscaling | `map(string)` | `{}` | no |
 | billing\_mode | Controls how you are billed for read/write throughput and how you manage capacity. The valid values are PROVISIONED or PAY\_PER\_REQUEST | `string` | `"PAY_PER_REQUEST"` | no |
 | create\_table | Controls if DynamoDB table and associated resources are created | `bool` | `true` | no |
 | global\_secondary\_indexes | Describe a GSI for the table; subject to the normal limits on the number of GSIs, projected attributes, etc. | `list(any)` | `[]` | no |
-| hash\_key | The attribute to use as the hash (partition) key. Must also be defined as an attribute | `string` | `null` | no |
+| hash\_key | The attribute to use as the hash (partition) key. Must also be defined as an attribute | `string` | n/a | yes |
 | local\_secondary\_indexes | Describe an LSI on the table; these can only be allocated at creation so you cannot change this definition after you have created the resource. | `list(any)` | `[]` | no |
-| name | Name of the DynamoDB table | `string` | `null` | no |
+| name | Name of the DynamoDB table | `string` | n/a | yes |
 | point\_in\_time\_recovery\_enabled | Whether to enable point-in-time recovery | `bool` | `false` | no |
-| range\_key | The attribute to use as the range (sort) key. Must also be defined as an attribute | `string` | `null` | no |
-| read\_capacity | The number of read units for this table. If the billing\_mode is PROVISIONED, this field should be greater than 0 | `number` | `null` | no |
+| range\_key | The attribute to use as the range (sort) key. Must also be defined as an attribute | `string` | n/a | yes |
+| read\_capacity | The number of read units for this table. If the billing\_mode is PROVISIONED, this field should be greater than 0 | `number` | n/a | yes |
 | server\_side\_encryption\_enabled | Whether or not to enable encryption at rest using an AWS managed KMS customer master key (CMK) | `bool` | `false` | no |
-| server\_side\_encryption\_kms\_key\_arn | The ARN of the CMK that should be used for the AWS KMS encryption. This attribute should only be specified if the key is different from the default DynamoDB CMK, alias/aws/dynamodb. | `string` | `null` | no |
+| server\_side\_encryption\_kms\_key\_arn | The ARN of the CMK that should be used for the AWS KMS encryption. This attribute should only be specified if the key is different from the default DynamoDB CMK, alias/aws/dynamodb. | `string` | n/a | yes |
 | stream\_enabled | Indicates whether Streams are to be enabled (true) or disabled (false). | `bool` | `false` | no |
-| stream\_view\_type | When an item in the table is modified, StreamViewType determines what information is written to the table's stream. Valid values are KEYS\_ONLY, NEW\_IMAGE, OLD\_IMAGE, NEW\_AND\_OLD\_IMAGES. | `string` | `null` | no |
+| stream\_view\_type | When an item in the table is modified, StreamViewType determines what information is written to the table's stream. Valid values are KEYS\_ONLY, NEW\_IMAGE, OLD\_IMAGE, NEW\_AND\_OLD\_IMAGES. | `string` | n/a | yes |
 | tags | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | timeouts | Updated Terraform resource management timeouts | `map(string)` | <pre>{<br>  "create": "10m",<br>  "delete": "10m",<br>  "update": "60m"<br>}</pre> | no |
 | ttl\_attribute\_name | The name of the table attribute to store the TTL timestamp in | `string` | `""` | no |
 | ttl\_enabled | Indicates whether ttl is enabled | `bool` | `false` | no |
-| write\_capacity | The number of write units for this table. If the billing\_mode is PROVISIONED, this field should be greater than 0 | `number` | `null` | no |
+| write\_capacity | The number of write units for this table. If the billing\_mode is PROVISIONED, this field should be greater than 0 | `number` | n/a | yes |
 
 ## Outputs
 

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -1,0 +1,111 @@
+resource "aws_appautoscaling_target" "table_read" {
+  count              = var.autoscaling_read_max_capacity > 0 ? 1 : 0
+  max_capacity       = var.autoscaling_read_max_capacity
+  min_capacity       = var.read_capacity
+  resource_id        = "table/${var.name}"
+  scalable_dimension = "dynamodb:table:ReadCapacityUnits"
+  service_namespace  = "dynamodb"
+}
+
+resource "aws_appautoscaling_policy" "table_read_policy" {
+  count              = var.autoscaling_read_max_capacity > 0 ? 1 : 0
+  name               = "DynamoDBReadCapacityUtilization:${aws_appautoscaling_target.table_read[0].resource_id}"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.table_read[0].resource_id
+  scalable_dimension = aws_appautoscaling_target.table_read[0].scalable_dimension
+  service_namespace  = aws_appautoscaling_target.table_read[0].service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "DynamoDBReadCapacityUtilization"
+    }
+
+    scale_in_cooldown  = 60
+    scale_out_cooldown = 60
+    target_value       = 70
+  }
+}
+
+resource "aws_appautoscaling_target" "table_write" {
+  count              = var.autoscaling_write_max_capacity > 0 ? 1 : 0
+  max_capacity       = var.autoscaling_write_max_capacity
+  min_capacity       = var.write_capacity
+  resource_id        = "table/${var.name}"
+  scalable_dimension = "dynamodb:table:WriteCapacityUnits"
+  service_namespace  = "dynamodb"
+}
+
+resource "aws_appautoscaling_policy" "table_write_policy" {
+  count              = var.autoscaling_write_max_capacity > 0 ? 1 : 0
+  name               = "DynamoDBReadCapacityUtilization:${aws_appautoscaling_target.table_write[0].resource_id}"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.table_write[0].resource_id
+  scalable_dimension = aws_appautoscaling_target.table_write[0].scalable_dimension
+  service_namespace  = aws_appautoscaling_target.table_write[0].service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "DynamoDBWriteCapacityUtilization"
+    }
+
+    scale_in_cooldown  = 60
+    scale_out_cooldown = 60
+    target_value       = 70
+  }
+}
+
+resource "aws_appautoscaling_target" "index_read" {
+  for_each           = var.autoscaling_indexes
+  max_capacity       = each.value["read_max_capacity"]
+  min_capacity       = each.value["read_min_capacity"]
+  resource_id        = "table/${var.name}/index/${each.key}"
+  scalable_dimension = "dynamodb:index:ReadCapacityUnits"
+  service_namespace  = "dynamodb"
+}
+
+resource "aws_appautoscaling_policy" "index_read_policy" {
+  for_each           = var.autoscaling_indexes
+  name               = "DynamoDBReadCapacityUtilization:${aws_appautoscaling_target.index_read[each.key].resource_id}"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.index_read[each.key].resource_id
+  scalable_dimension = aws_appautoscaling_target.index_read[each.key].scalable_dimension
+  service_namespace  = aws_appautoscaling_target.index_read[each.key].service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "DynamoDBReadCapacityUtilization"
+    }
+
+    scale_in_cooldown  = 60
+    scale_out_cooldown = 60
+    target_value       = 70
+  }
+}
+
+resource "aws_appautoscaling_target" "index_write" {
+  for_each           = var.autoscaling_indexes
+  max_capacity       = each.value["write_max_capacity"]
+  min_capacity       = each.value["write_min_capacity"]
+  resource_id        = "table/${var.name}/index/${each.key}"
+  scalable_dimension = "dynamodb:index:WriteCapacityUnits"
+  service_namespace  = "dynamodb"
+}
+
+resource "aws_appautoscaling_policy" "index_write_policy" {
+  for_each           = var.autoscaling_indexes
+  name               = "DynamoDBReadCapacityUtilization:${aws_appautoscaling_target.index_write[each.key].resource_id}"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.index_write[each.key].resource_id
+  scalable_dimension = aws_appautoscaling_target.index_write[each.key].scalable_dimension
+  service_namespace  = aws_appautoscaling_target.index_write[each.key].service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "DynamoDBWriteCapacityUtilization"
+    }
+
+    scale_in_cooldown  = 60
+    scale_out_cooldown = 60
+    target_value       = 70
+  }
+}

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -1,6 +1,6 @@
 resource "aws_appautoscaling_target" "table_read" {
-  count              = var.autoscaling_read_max_capacity > 0 ? 1 : 0
-  max_capacity       = var.autoscaling_read_max_capacity
+  count              = length(var.autoscaling_read) > 0 ? 1 : 0
+  max_capacity       = var.autoscaling_read["max_capacity"]
   min_capacity       = var.read_capacity
   resource_id        = "table/${var.name}"
   scalable_dimension = "dynamodb:table:ReadCapacityUnits"
@@ -8,7 +8,7 @@ resource "aws_appautoscaling_target" "table_read" {
 }
 
 resource "aws_appautoscaling_policy" "table_read_policy" {
-  count              = var.autoscaling_read_max_capacity > 0 ? 1 : 0
+  count              = length(var.autoscaling_read) > 0 ? 1 : 0
   name               = "DynamoDBReadCapacityUtilization:${aws_appautoscaling_target.table_read[0].resource_id}"
   policy_type        = "TargetTrackingScaling"
   resource_id        = aws_appautoscaling_target.table_read[0].resource_id
@@ -20,15 +20,15 @@ resource "aws_appautoscaling_policy" "table_read_policy" {
       predefined_metric_type = "DynamoDBReadCapacityUtilization"
     }
 
-    scale_in_cooldown  = var.autoscaling_scale_in_cooldown
-    scale_out_cooldown = var.autoscaling_scale_out_cooldown
-    target_value       = var.autoscaling_target_value
+    scale_in_cooldown  = lookup(var.autoscaling_read, "scale_in_cooldown", var.autoscaling_defaults["scale_in_cooldown"])
+    scale_out_cooldown = lookup(var.autoscaling_read, "scale_out_cooldown", var.autoscaling_defaults["scale_out_cooldown"])
+    target_value       = lookup(var.autoscaling_read, "target_value", var.autoscaling_defaults["target_value"])
   }
 }
 
 resource "aws_appautoscaling_target" "table_write" {
-  count              = var.autoscaling_write_max_capacity > 0 ? 1 : 0
-  max_capacity       = var.autoscaling_write_max_capacity
+  count              = length(var.autoscaling_write) > 0 ? 1 : 0
+  max_capacity       = var.autoscaling_write["max_capacity"]
   min_capacity       = var.write_capacity
   resource_id        = "table/${var.name}"
   scalable_dimension = "dynamodb:table:WriteCapacityUnits"
@@ -36,7 +36,7 @@ resource "aws_appautoscaling_target" "table_write" {
 }
 
 resource "aws_appautoscaling_policy" "table_write_policy" {
-  count              = var.autoscaling_write_max_capacity > 0 ? 1 : 0
+  count              = length(var.autoscaling_write) > 0 ? 1 : 0
   name               = "DynamoDBReadCapacityUtilization:${aws_appautoscaling_target.table_write[0].resource_id}"
   policy_type        = "TargetTrackingScaling"
   resource_id        = aws_appautoscaling_target.table_write[0].resource_id
@@ -48,9 +48,9 @@ resource "aws_appautoscaling_policy" "table_write_policy" {
       predefined_metric_type = "DynamoDBWriteCapacityUtilization"
     }
 
-    scale_in_cooldown  = var.autoscaling_scale_in_cooldown
-    scale_out_cooldown = var.autoscaling_scale_out_cooldown
-    target_value       = var.autoscaling_target_value
+    scale_in_cooldown  = lookup(var.autoscaling_read, "scale_in_cooldown", var.autoscaling_defaults["scale_in_cooldown"])
+    scale_out_cooldown = lookup(var.autoscaling_read, "scale_out_cooldown", var.autoscaling_defaults["scale_out_cooldown"])
+    target_value       = lookup(var.autoscaling_read, "target_value", var.autoscaling_defaults["target_value"])
   }
 }
 
@@ -76,9 +76,9 @@ resource "aws_appautoscaling_policy" "index_read_policy" {
       predefined_metric_type = "DynamoDBReadCapacityUtilization"
     }
 
-    scale_in_cooldown  = var.autoscaling_scale_in_cooldown
-    scale_out_cooldown = var.autoscaling_scale_out_cooldown
-    target_value       = var.autoscaling_target_value
+    scale_in_cooldown  = merge(var.autoscaling_defaults, each.value)["scale_in_cooldown"]
+    scale_out_cooldown = merge(var.autoscaling_defaults, each.value)["scale_out_cooldown"]
+    target_value       = merge(var.autoscaling_defaults, each.value)["target_value"]
   }
 }
 
@@ -104,8 +104,8 @@ resource "aws_appautoscaling_policy" "index_write_policy" {
       predefined_metric_type = "DynamoDBWriteCapacityUtilization"
     }
 
-    scale_in_cooldown  = var.autoscaling_scale_in_cooldown
-    scale_out_cooldown = var.autoscaling_scale_out_cooldown
-    target_value       = var.autoscaling_target_value
+    scale_in_cooldown  = merge(var.autoscaling_defaults, each.value)["scale_in_cooldown"]
+    scale_out_cooldown = merge(var.autoscaling_defaults, each.value)["scale_out_cooldown"]
+    target_value       = merge(var.autoscaling_defaults, each.value)["target_value"]
   }
 }

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -20,9 +20,9 @@ resource "aws_appautoscaling_policy" "table_read_policy" {
       predefined_metric_type = "DynamoDBReadCapacityUtilization"
     }
 
-    scale_in_cooldown  = 60
-    scale_out_cooldown = 60
-    target_value       = 70
+    scale_in_cooldown  = var.autoscaling_scale_in_cooldown
+    scale_out_cooldown = var.autoscaling_scale_out_cooldown
+    target_value       = var.autoscaling_target_value
   }
 }
 
@@ -48,9 +48,9 @@ resource "aws_appautoscaling_policy" "table_write_policy" {
       predefined_metric_type = "DynamoDBWriteCapacityUtilization"
     }
 
-    scale_in_cooldown  = 60
-    scale_out_cooldown = 60
-    target_value       = 70
+    scale_in_cooldown  = var.autoscaling_scale_in_cooldown
+    scale_out_cooldown = var.autoscaling_scale_out_cooldown
+    target_value       = var.autoscaling_target_value
   }
 }
 
@@ -76,9 +76,9 @@ resource "aws_appautoscaling_policy" "index_read_policy" {
       predefined_metric_type = "DynamoDBReadCapacityUtilization"
     }
 
-    scale_in_cooldown  = 60
-    scale_out_cooldown = 60
-    target_value       = 70
+    scale_in_cooldown  = var.autoscaling_scale_in_cooldown
+    scale_out_cooldown = var.autoscaling_scale_out_cooldown
+    target_value       = var.autoscaling_target_value
   }
 }
 
@@ -104,8 +104,8 @@ resource "aws_appautoscaling_policy" "index_write_policy" {
       predefined_metric_type = "DynamoDBWriteCapacityUtilization"
     }
 
-    scale_in_cooldown  = 60
-    scale_out_cooldown = 60
-    target_value       = 70
+    scale_in_cooldown  = var.autoscaling_scale_in_cooldown
+    scale_out_cooldown = var.autoscaling_scale_out_cooldown
+    target_value       = var.autoscaling_target_value
   }
 }

--- a/examples/autoscaling/README.md
+++ b/examples/autoscaling/README.md
@@ -15,10 +15,6 @@ $ terraform apply
 Note that this example may create resources which can cost money (AWS Elastic IP, for example). Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-## Requirements
-
-No requirements.
-
 ## Providers
 
 | Name | Version |

--- a/examples/autoscaling/README.md
+++ b/examples/autoscaling/README.md
@@ -15,6 +15,10 @@ $ terraform apply
 Note that this example may create resources which can cost money (AWS Elastic IP, for example). Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
 ## Providers
 
 | Name | Version |

--- a/examples/autoscaling/README.md
+++ b/examples/autoscaling/README.md
@@ -1,0 +1,37 @@
+# DynamoDB Table autoscaling example
+
+Configuration in this directory creates AWS DynamoDB table with autoscaling.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example may create resources which can cost money (AWS Elastic IP, for example). Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| random | n/a |
+
+## Inputs
+
+No input.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| this\_dynamodb\_table\_arn | ARN of the DynamoDB table |
+| this\_dynamodb\_table\_id | ID of the DynamoDB table |
+| this\_dynamodb\_table\_stream\_arn | The ARN of the Table Stream. Only available when var.stream\_enabled is true |
+| this\_dynamodb\_table\_stream\_label | A timestamp, in ISO 8601 format of the Table Stream. Only available when var.stream\_enabled is true |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/autoscaling/main.tf
+++ b/examples/autoscaling/main.tf
@@ -1,0 +1,68 @@
+provider "aws" {
+  region = "eu-west-1"
+}
+
+resource "random_pet" "this" {
+  length = 2
+}
+
+module "dynamodb_table" {
+  source = "../../"
+
+  name                           = "my-table-${random_pet.this.id}"
+  hash_key                       = "id"
+  range_key                      = "title"
+  billing_mode                   = "PROVISIONED"
+  write_capacity                 = 5
+  read_capacity                  = 5
+  autoscaling_read_max_capacity  = 20
+  autoscaling_write_max_capacity = 20
+
+  autoscaling_indexes = {
+    TitleIndex = {
+      read_max_capacity  = 30
+      read_min_capacity  = 5
+      write_max_capacity = 30
+      write_min_capacity = 5
+    }
+  }
+
+  attributes = [
+    {
+      name = "id"
+      type = "N"
+    },
+    {
+      name = "title"
+      type = "S"
+    },
+    {
+      name = "age"
+      type = "N"
+    }
+  ]
+
+  global_secondary_indexes = [
+    {
+      name               = "TitleIndex"
+      hash_key           = "title"
+      range_key          = "age"
+      projection_type    = "INCLUDE"
+      non_key_attributes = ["id"]
+      write_capacity     = 10
+      read_capacity      = 10
+    }
+  ]
+
+
+  tags = {
+    Terraform   = "true"
+    Environment = "staging"
+  }
+}
+
+module "disabled_dynamodb_table" {
+  source = "../../"
+
+  create_table = false
+}

--- a/examples/autoscaling/main.tf
+++ b/examples/autoscaling/main.tf
@@ -9,21 +9,33 @@ resource "random_pet" "this" {
 module "dynamodb_table" {
   source = "../../"
 
-  name                           = "my-table-${random_pet.this.id}"
-  hash_key                       = "id"
-  range_key                      = "title"
-  billing_mode                   = "PROVISIONED"
-  write_capacity                 = 5
-  read_capacity                  = 5
-  autoscaling_read_max_capacity  = 20
-  autoscaling_write_max_capacity = 20
+  name           = "my-table-${random_pet.this.id}"
+  hash_key       = "id"
+  range_key      = "title"
+  billing_mode   = "PROVISIONED"
+  read_capacity  = 5
+  write_capacity = 5
+
+  autoscaling_read = {
+    scale_in_cooldown  = 50
+    scale_out_cooldown = 40
+    target_value       = 45
+    max_capacity       = 10
+  }
+
+  autoscaling_write = {
+    scale_in_cooldown  = 50
+    scale_out_cooldown = 40
+    target_value       = 45
+    max_capacity       = 10
+  }
 
   autoscaling_indexes = {
     TitleIndex = {
       read_max_capacity  = 30
-      read_min_capacity  = 5
+      read_min_capacity  = 10
       write_max_capacity = 30
-      write_min_capacity = 5
+      write_min_capacity = 10
     }
   }
 
@@ -53,7 +65,6 @@ module "dynamodb_table" {
       read_capacity      = 10
     }
   ]
-
 
   tags = {
     Terraform   = "true"

--- a/examples/autoscaling/outputs.tf
+++ b/examples/autoscaling/outputs.tf
@@ -1,0 +1,19 @@
+output "this_dynamodb_table_arn" {
+  description = "ARN of the DynamoDB table"
+  value       = module.dynamodb_table.this_dynamodb_table_arn
+}
+
+output "this_dynamodb_table_id" {
+  description = "ID of the DynamoDB table"
+  value       = module.dynamodb_table.this_dynamodb_table_id
+}
+
+output "this_dynamodb_table_stream_arn" {
+  description = "The ARN of the Table Stream. Only available when var.stream_enabled is true"
+  value       = module.dynamodb_table.this_dynamodb_table_stream_arn
+}
+
+output "this_dynamodb_table_stream_label" {
+  description = "A timestamp, in ISO 8601 format of the Table Stream. Only available when var.stream_enabled is true"
+  value       = module.dynamodb_table.this_dynamodb_table_stream_label
+}

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -15,10 +15,6 @@ $ terraform apply
 Note that this example may create resources which can cost money (AWS Elastic IP, for example). Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-## Requirements
-
-No requirements.
-
 ## Providers
 
 | Name | Version |

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -15,6 +15,10 @@ $ terraform apply
 Note that this example may create resources which can cost money (AWS Elastic IP, for example). Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
 ## Providers
 
 | Name | Version |

--- a/variables.tf
+++ b/variables.tf
@@ -118,15 +118,7 @@ variable "timeouts" {
 
 variable "autoscaling_defaults" {
   description = "A map of default autoscaling settings"
-
-  type = object(
-    {
-      scale_in_cooldown  = number
-      scale_out_cooldown = number
-      target_value       = number
-    }
-  )
-
+  type        = map(string)
   default = {
     scale_in_cooldown  = 0
     scale_out_cooldown = 0

--- a/variables.tf
+++ b/variables.tf
@@ -115,3 +115,34 @@ variable "timeouts" {
     delete = "10m"
   }
 }
+
+variable "autoscaling_read_max_capacity" {
+  description = "Determines the maximum amount of read capacity the autoscaling is enable to scale. If defined will create an autoscaling structure"
+  default     = 0
+}
+
+variable "autoscaling_write_max_capacity" {
+  description = "Determines the maximum amount of write capacity the autoscaling is enable to scale. If defined will create an autoscaling structure"
+  default     = 0
+}
+
+variable "autoscaling_scale_in_cooldown" {
+  description = "The amount of time, in seconds, after a scale in activity completes before another scale in activity can start"
+  default     = 60
+}
+
+variable "autoscaling_scale_out_cooldown" {
+  description = "The amount of time, in seconds, after a scale out activity completes before another scale out activity can start"
+  default     = 60
+}
+
+variable "autoscaling_target_value" {
+  description = "The target value for the autoscaling metric"
+  default     = 50
+}
+
+variable "autoscaling_indexes" {
+  description = "A map of index autoscaling configurations. See example in examples/autoscaling"
+  type        = map(map(string))
+  default     = {}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -116,33 +116,34 @@ variable "timeouts" {
   }
 }
 
-variable "autoscaling_read_max_capacity" {
-  description = "Determines the maximum amount of read capacity the autoscaling is enable to scale. If defined will create an autoscaling structure"
-  default     = 0
+variable "autoscaling_defaults" {
+  description = "A map of default autoscaling settings"
+
+  type = object(
+    {
+      scale_in_cooldown  = number
+      scale_out_cooldown = number
+      target_value       = number
+    }
+  )
+
+  default = {
+    scale_in_cooldown  = 0
+    scale_out_cooldown = 0
+    target_value       = 70
+  }
 }
 
-variable "autoscaling_write_max_capacity" {
-  description = "Determines the maximum amount of write capacity the autoscaling is enable to scale. If defined will create an autoscaling structure"
-  type        = number
-  default     = 0
+variable "autoscaling_read" {
+  description = "A map of read autoscaling settings. `max_capacity` is the only required key. See example in examples/autoscaling"
+  type        = map(string)
+  default     = {}
 }
 
-variable "autoscaling_scale_in_cooldown" {
-  description = "The amount of time, in seconds, after a scale in activity completes before another scale in activity can start"
-  type        = number
-  default     = 60
-}
-
-variable "autoscaling_scale_out_cooldown" {
-  description = "The amount of time, in seconds, after a scale out activity completes before another scale out activity can start"
-  type        = number
-  default     = 60
-}
-
-variable "autoscaling_target_value" {
-  description = "The target value for the autoscaling metric"
-  type        = number
-  default     = 50
+variable "autoscaling_write" {
+  description = "A map of write autoscaling settings. `max_capacity` is the only required key. See example in examples/autoscaling"
+  type        = map(string)
+  default     = {}
 }
 
 variable "autoscaling_indexes" {

--- a/variables.tf
+++ b/variables.tf
@@ -123,21 +123,25 @@ variable "autoscaling_read_max_capacity" {
 
 variable "autoscaling_write_max_capacity" {
   description = "Determines the maximum amount of write capacity the autoscaling is enable to scale. If defined will create an autoscaling structure"
+  type        = number
   default     = 0
 }
 
 variable "autoscaling_scale_in_cooldown" {
   description = "The amount of time, in seconds, after a scale in activity completes before another scale in activity can start"
+  type        = number
   default     = 60
 }
 
 variable "autoscaling_scale_out_cooldown" {
   description = "The amount of time, in seconds, after a scale out activity completes before another scale out activity can start"
+  type        = number
   default     = 60
 }
 
 variable "autoscaling_target_value" {
   description = "The target value for the autoscaling metric"
+  type        = number
   default     = 50
 }
 


### PR DESCRIPTION
## Description

Adding optional autoscaling for the table.

Resolves https://github.com/terraform-aws-modules/terraform-aws-dynamodb-table/issues/9

## Motivation and Context

It's one of the main advantages of DynamoDB

## Breaking Changes

No.

## How Has This Been Tested?

I've done `terraform apply` and `terraform destroy` and verified that the autoscaling settings are set correctly in the AWS console.