### PR TITLE
fix: Lookup non_key_attributes in local_secondary_index.value

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ resource "aws_dynamodb_table" "this" {
       name               = local_secondary_index.value.name
       range_key          = local_secondary_index.value.range_key
       projection_type    = local_secondary_index.value.projection_type
-      non_key_attributes = lookup(global_secondary_index.value, "non_key_attributes", null)
+      non_key_attributes = lookup(local_secondary_index.value, "non_key_attributes", null)
     }
   }
 


### PR DESCRIPTION
## Description
This fixes a bug where you could not create local secondary indexes.

## Motivation and Context
Local secondary indexes could not be created. Defining a local secondary index caused the terraform operation to fail with an error.
```
Error: Reference to undeclared resource

  on .terraform/modules/export_process_batch/terraform-aws-dynamodb-table-0.4.0/main.tf line 38, in resource "aws_dynamodb_table" "this":
  38:       non_key_attributes = lookup(global_secondary_index.value, "non_key_attributes", null)
``` 

## Breaking Changes
No breaking. Only fixing!

## How Has This Been Tested?

I implemented a terraform module that is based on this branch and used it to create a dynamodb table with a local secondary index.
