### PR TITLE
fix: Use correct write policy name for table and index autoscaling rules

### DIFF
--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -37,7 +37,7 @@ resource "aws_appautoscaling_target" "table_write" {
 
 resource "aws_appautoscaling_policy" "table_write_policy" {
   count              = length(var.autoscaling_write) > 0 ? 1 : 0
-  name               = "DynamoDBReadCapacityUtilization:${aws_appautoscaling_target.table_write[0].resource_id}"
+  name               = "DynamoDBWriteCapacityUtilization:${aws_appautoscaling_target.table_write[0].resource_id}"
   policy_type        = "TargetTrackingScaling"
   resource_id        = aws_appautoscaling_target.table_write[0].resource_id
   scalable_dimension = aws_appautoscaling_target.table_write[0].scalable_dimension
@@ -93,7 +93,7 @@ resource "aws_appautoscaling_target" "index_write" {
 
 resource "aws_appautoscaling_policy" "index_write_policy" {
   for_each           = var.autoscaling_indexes
-  name               = "DynamoDBReadCapacityUtilization:${aws_appautoscaling_target.index_write[each.key].resource_id}"
+  name               = "DynamoDBWriteCapacityUtilization:${aws_appautoscaling_target.index_write[each.key].resource_id}"
   policy_type        = "TargetTrackingScaling"
   resource_id        = aws_appautoscaling_target.index_write[each.key].resource_id
   scalable_dimension = aws_appautoscaling_target.index_write[each.key].scalable_dimension


### PR DESCRIPTION
## Description
This fixes a bug where an incorrect rule for write capacity autoscaling would be created.

## Motivation and Context
Write capacity autoscaling rules were named for read capacity.

## Breaking Changes
No breaking. Only fixing!
