### PR TITLE
feat: Add replica configuration to create global DynamoDB tables

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.31.0
+    rev: v1.41.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.1.0
+    rev: v3.2.0
     hooks:
       - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Terraform module to create a DynamoDB table.
 
-This type of resources are supported:
+This type of resources supported:
 
 * [DynamoDB table](https://www.terraform.io/docs/providers/aws/r/dynamodb_table.html)
 
@@ -36,6 +36,8 @@ module "dynamodb_table" {
 ## Examples
 
 * [Basic example](https://github.com/terraform-aws-modules/terraform-aws-dynamodb-table/tree/master/examples/basic)
+* [Autoscaling example](https://github.com/terraform-aws-modules/terraform-aws-dynamodb-table/tree/master/examples/autoscaling)
+* [Global tables example](https://github.com/terraform-aws-modules/terraform-aws-dynamodb-table/tree/master/examples/global-tables)
 
 ## Change log
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The [change log](https://github.com/terraform-aws-modules/terraform-aws-dynamodb
 | point\_in\_time\_recovery\_enabled | Whether to enable point-in-time recovery | `bool` | `false` | no |
 | range\_key | The attribute to use as the range (sort) key. Must also be defined as an attribute | `string` | `null` | no |
 | read\_capacity | The number of read units for this table. If the billing\_mode is PROVISIONED, this field should be greater than 0 | `number` | `null` | no |
+| replica\_regions | Region names for creating replicas for a global DynamoDB table. | `list(string)` | `[]` | no |
 | server\_side\_encryption\_enabled | Whether or not to enable encryption at rest using an AWS managed KMS customer master key (CMK) | `bool` | `false` | no |
 | server\_side\_encryption\_kms\_key\_arn | The ARN of the CMK that should be used for the AWS KMS encryption. This attribute should only be specified if the key is different from the default DynamoDB CMK, alias/aws/dynamodb. | `string` | `null` | no |
 | stream\_enabled | Indicates whether Streams are to be enabled (true) or disabled (false). | `bool` | `false` | no |

--- a/examples/global-tables/README.md
+++ b/examples/global-tables/README.md
@@ -1,0 +1,41 @@
+# DynamoDB Table example
+
+Configuration in this directory creates a Global AWS DynamoDB table with replicas in eu-west-1 and eu-west2.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example may create resources which can cost money (AWS Elastic IP, for example). Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| random | n/a |
+
+## Inputs
+
+No input.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| this\_dynamodb\_table\_arn | ARN of the DynamoDB table |
+| this\_dynamodb\_table\_id | ID of the DynamoDB table |
+| this\_dynamodb\_table\_stream\_arn | The ARN of the Table Stream. Only available when var.stream\_enabled is true |
+| this\_dynamodb\_table\_stream\_label | A timestamp, in ISO 8601 format of the Table Stream. Only available when var.stream\_enabled is true |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/global-tables/README.md
+++ b/examples/global-tables/README.md
@@ -1,6 +1,6 @@
 # DynamoDB Table example
 
-Configuration in this directory creates a Global AWS DynamoDB table with replicas in eu-west-1 and eu-west2.
+Configuration in this directory creates a Global AWS DynamoDB table with replicas in eu-west-1 and eu-west-2 regions.
 
 ## Usage
 

--- a/examples/global-tables/main.tf
+++ b/examples/global-tables/main.tf
@@ -1,0 +1,49 @@
+provider "aws" {
+  region = "eu-west-1"
+}
+
+resource "random_pet" "this" {
+  length = 2
+}
+
+module "dynamodb_table" {
+  source = "../../"
+
+  name      = "my-table-${random_pet.this.id}"
+  hash_key  = "id"
+  range_key = "title"
+
+  attributes = [
+    {
+      name = "id"
+      type = "N"
+    },
+    {
+      name = "title"
+      type = "S"
+    },
+    {
+      name = "age"
+      type = "N"
+    }
+  ]
+
+  global_secondary_indexes = [
+    {
+      name               = "TitleIndex"
+      hash_key           = "title"
+      range_key          = "age"
+      projection_type    = "INCLUDE"
+      non_key_attributes = ["id"]
+    }
+  ]
+
+  replica_regions = [
+    "eu-west-2"
+  ]
+
+  tags = {
+    Terraform   = "true"
+    Environment = "staging"
+  }
+}

--- a/examples/global-tables/outputs.tf
+++ b/examples/global-tables/outputs.tf
@@ -1,0 +1,19 @@
+output "this_dynamodb_table_arn" {
+  description = "ARN of the DynamoDB table"
+  value       = module.dynamodb_table.this_dynamodb_table_arn
+}
+
+output "this_dynamodb_table_id" {
+  description = "ID of the DynamoDB table"
+  value       = module.dynamodb_table.this_dynamodb_table_id
+}
+
+output "this_dynamodb_table_stream_arn" {
+  description = "The ARN of the Table Stream. Only available when var.stream_enabled is true"
+  value       = module.dynamodb_table.this_dynamodb_table_stream_arn
+}
+
+output "this_dynamodb_table_stream_label" {
+  description = "A timestamp, in ISO 8601 format of the Table Stream. Only available when var.stream_enabled is true"
+  value       = module.dynamodb_table.this_dynamodb_table_stream_label
+}

--- a/main.tf
+++ b/main.tf
@@ -53,6 +53,14 @@ resource "aws_dynamodb_table" "this" {
     }
   }
 
+  dynamic "replica" {
+    for_each = var.replica_regions
+
+    content {
+      region_name = replica.value
+    }
+  }
+
   server_side_encryption {
     enabled     = var.server_side_encryption_enabled
     kms_key_arn = var.server_side_encryption_kms_key_arn

--- a/variables.tf
+++ b/variables.tf
@@ -76,6 +76,12 @@ variable "local_secondary_indexes" {
   default     = []
 }
 
+variable "replica_regions" {
+  description = "Region names for creating replicas for a global DynamoDB table."
+  type        = list(string)
+  default     = []
+}
+
 variable "stream_enabled" {
   description = "Indicates whether Streams are to be enabled (true) or disabled (false)."
   type        = bool


### PR DESCRIPTION
fixed: removed stuff

## Description
Adding replica regions to create global DynamoDB tables

## Motivation and Context
Resolves #19

## Breaking Changes
No

## How Has This Been Tested?
Run `terraform apply` and `terraform destroy` on the global-tables example folder.
