### PR TITLE
fix: use proper var for aws_appautoscaling_policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ The [change log](https://github.com/terraform-aws-modules/terraform-aws-dynamodb
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6 |
-| aws | >= 2.52 |
+| aws | >= 2.58 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.52 |
+| aws | >= 2.58 |
 
 ## Inputs
 

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -52,9 +52,9 @@ resource "aws_appautoscaling_policy" "table_write_policy" {
       predefined_metric_type = "DynamoDBWriteCapacityUtilization"
     }
 
-    scale_in_cooldown  = lookup(var.autoscaling_read, "scale_in_cooldown", var.autoscaling_defaults["scale_in_cooldown"])
-    scale_out_cooldown = lookup(var.autoscaling_read, "scale_out_cooldown", var.autoscaling_defaults["scale_out_cooldown"])
-    target_value       = lookup(var.autoscaling_read, "target_value", var.autoscaling_defaults["target_value"])
+    scale_in_cooldown  = lookup(var.autoscaling_write, "scale_in_cooldown", var.autoscaling_defaults["scale_in_cooldown"])
+    scale_out_cooldown = lookup(var.autoscaling_write, "scale_out_cooldown", var.autoscaling_defaults["scale_out_cooldown"])
+    target_value       = lookup(var.autoscaling_write, "target_value", var.autoscaling_defaults["target_value"])
   }
 }
 

--- a/examples/autoscaling/README.md
+++ b/examples/autoscaling/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6 |
-| aws | >= 2.52 |
+| aws | >= 2.58 |
 | random | >= 2.0 |
 
 ## Providers

--- a/examples/autoscaling/versions.tf
+++ b/examples/autoscaling/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws    = ">= 2.52"
+    aws    = ">= 2.58"
     random = ">= 2.0"
   }
 }

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6 |
-| aws | >= 2.52 |
+| aws | >= 2.58 |
 | random | >= 2.0 |
 
 ## Providers

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws    = ">= 2.52"
+    aws    = ">= 2.58"
     random = ">= 2.0"
   }
 }

--- a/examples/global-tables/README.md
+++ b/examples/global-tables/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6 |
-| aws | >= 2.52 |
+| aws | >= 2.58 |
 | random | >= 2.0 |
 
 ## Providers

--- a/examples/global-tables/versions.tf
+++ b/examples/global-tables/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws    = ">= 2.52"
+    aws    = ">= 2.58"
     random = ">= 2.0"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws = ">= 2.52"
+    aws = ">= 2.58"
   }
 }


### PR DESCRIPTION
## Description
We should use autoscaling_write instead of autoscaling_read variable for
aws_appautoscaling_policy.table_write_policy.

Also, the minimal version of the aws provider is 2.58. Lower versions do
not support 'replica' block.

## Motivation and Context
Otherwise write auto-scaling uses read arguments

## Breaking Changes
n/a

## How Has This Been Tested?
I tried to apply this, and `autoscaling_write` map arguments weren't applied before.