### PR TITLE
chore: update documentation based on latest `terraform-docs` which includes module and resource sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,29 @@
-.terraform
-terraform.tfstate
-*.tfstate*
-terraform.tfvars
+# Local .terraform directories
+**/.terraform/*
+
+# Terraform lockfile
+.terraform.lock.hcl
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.45.0
+    rev: v1.46.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.44.0
+    rev: v1.45.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -21,6 +21,6 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v3.4.0
     hooks:
       - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ The [change log](https://github.com/terraform-aws-modules/terraform-aws-dynamodb
 |------|---------|
 | aws | >= 2.58 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_appautoscaling_policy](https://registry.terraform.io/providers/hashicorp/aws/2.58/docs/resources/appautoscaling_policy) |
+| [aws_appautoscaling_target](https://registry.terraform.io/providers/hashicorp/aws/2.58/docs/resources/appautoscaling_target) |
+| [aws_dynamodb_table](https://registry.terraform.io/providers/hashicorp/aws/2.58/docs/resources/dynamodb_table) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -94,7 +106,6 @@ The [change log](https://github.com/terraform-aws-modules/terraform-aws-dynamodb
 | this\_dynamodb\_table\_id | ID of the DynamoDB table |
 | this\_dynamodb\_table\_stream\_arn | The ARN of the Table Stream. Only available when var.stream\_enabled is true |
 | this\_dynamodb\_table\_stream\_label | A timestamp, in ISO 8601 format of the Table Stream. Only available when var.stream\_enabled is true |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/examples/autoscaling/README.md
+++ b/examples/autoscaling/README.md
@@ -29,6 +29,19 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 |------|---------|
 | random | >= 2.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| disabled_dynamodb_table | ../../ |  |
+| dynamodb_table | ../../ |  |
+
+## Resources
+
+| Name |
+|------|
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2.0/docs/resources/pet) |
+
 ## Inputs
 
 No input.
@@ -41,5 +54,4 @@ No input.
 | this\_dynamodb\_table\_id | ID of the DynamoDB table |
 | this\_dynamodb\_table\_stream\_arn | The ARN of the Table Stream. Only available when var.stream\_enabled is true |
 | this\_dynamodb\_table\_stream\_label | A timestamp, in ISO 8601 format of the Table Stream. Only available when var.stream\_enabled is true |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -29,6 +29,19 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 |------|---------|
 | random | >= 2.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| disabled_dynamodb_table | ../../ |  |
+| dynamodb_table | ../../ |  |
+
+## Resources
+
+| Name |
+|------|
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2.0/docs/resources/pet) |
+
 ## Inputs
 
 No input.
@@ -41,5 +54,4 @@ No input.
 | this\_dynamodb\_table\_id | ID of the DynamoDB table |
 | this\_dynamodb\_table\_stream\_arn | The ARN of the Table Stream. Only available when var.stream\_enabled is true |
 | this\_dynamodb\_table\_stream\_label | A timestamp, in ISO 8601 format of the Table Stream. Only available when var.stream\_enabled is true |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/global-tables/README.md
+++ b/examples/global-tables/README.md
@@ -29,6 +29,18 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 |------|---------|
 | random | >= 2.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| dynamodb_table | ../../ |  |
+
+## Resources
+
+| Name |
+|------|
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2.0/docs/resources/pet) |
+
 ## Inputs
 
 No input.
@@ -41,5 +53,4 @@ No input.
 | this\_dynamodb\_table\_id | ID of the DynamoDB table |
 | this\_dynamodb\_table\_stream\_arn | The ARN of the Table Stream. Only available when var.stream\_enabled is true |
 | this\_dynamodb\_table\_stream\_label | A timestamp, in ISO 8601 format of the Table Stream. Only available when var.stream\_enabled is true |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
## Description
- update documentation based on latest `terraform-docs` which includes module and resource sections
- `.gitignore` updated using GitHub provided default standard + 0.14 lockfile ignore

## Motivation and Context
- these are two new sections provided by [`terraform-docs` now](https://github.com/terraform-docs/terraform-docs/releases/tag/v0.11.0)

## Breaking Changes
No

## How Has This Been Tested?
N/A
