### PR TITLE
fix: Update global example to enable stream

### DIFF
--- a/examples/global-tables/main.tf
+++ b/examples/global-tables/main.tf
@@ -12,6 +12,8 @@ module "dynamodb_table" {
   name      = "my-table-${random_pet.this.id}"
   hash_key  = "id"
   range_key = "title"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
 
   attributes = [
     {

--- a/examples/global-tables/main.tf
+++ b/examples/global-tables/main.tf
@@ -9,9 +9,9 @@ resource "random_pet" "this" {
 module "dynamodb_table" {
   source = "../../"
 
-  name      = "my-table-${random_pet.this.id}"
-  hash_key  = "id"
-  range_key = "title"
+  name             = "my-table-${random_pet.this.id}"
+  hash_key         = "id"
+  range_key        = "title"
   stream_enabled   = true
   stream_view_type = "NEW_AND_OLD_IMAGES"
 


### PR DESCRIPTION
## Description
Fix global table example. Global tables require streams to be enabled.

## Motivation and Context
Without this change, the following error will be thrown when the example is applied:
`ValidationException: One or more parameter values were invalid: Disabling Stream is not allowed for a Global Table replica.`

## Breaking Changes
None

## How Has This Been Tested?
I have tested this on my own account by referencing the v0.12.0 release of this module and attempting to apply without these changes, and then again with these changes. Without these changes there is an error (above), and with these changes the error is removed and the global replica is successfully created.
