### PR TITLE
Add consume alarms

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,10 @@ module "dynamodb_table" {
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_ddb_consume_read_capacity_alarms"></a> [ddb\_consume\_read\_capacity\_alarms](#module\_ddb\_consume\_read\_capacity\_alarms) | terraform-aws-modules/cloudwatch/aws//modules/metric-alarm |  |
+| <a name="module_ddb_consume_write_capacity_alarms"></a> [ddb\_consume\_write\_capacity\_alarms](#module\_ddb\_consume\_write\_capacity\_alarms) | terraform-aws-modules/cloudwatch/aws//modules/metric-alarm |  |
 
 ## Resources
 
@@ -67,6 +70,8 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_alarm_actions"></a> [alarm\_actions](#input\_alarm\_actions) | The list of actions to execute when this alarm transitions into an ALARM state from any other state. Each action is specified as an Amazon Resource Name (ARN). | `list(string)` | `[]` | no |
+| <a name="input_alarm_defaults"></a> [alarm\_defaults](#input\_alarm\_defaults) | A map with alarm settings. 'period' and 'evaluation\_periods' are the only required. See example/autoscaling | `map(string)` | `{}` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | List of nested attribute definitions. Only required for hash\_key and range\_key attributes. Each attribute has two properties: name - (Required) The name of the attribute, type - (Required) Attribute type, which must be a scalar type: S, N, or B for (S)tring, (N)umber or (B)inary data | `list(map(string))` | `[]` | no |
 | <a name="input_autoscaling_defaults"></a> [autoscaling\_defaults](#input\_autoscaling\_defaults) | A map of default autoscaling settings | `map(string)` | <pre>{<br>  "scale_in_cooldown": 0,<br>  "scale_out_cooldown": 0,<br>  "target_value": 70<br>}</pre> | no |
 | <a name="input_autoscaling_indexes"></a> [autoscaling\_indexes](#input\_autoscaling\_indexes) | A map of index autoscaling configurations. See example in examples/autoscaling | `map(map(string))` | `{}` | no |

--- a/alarms.tf
+++ b/alarms.tf
@@ -1,0 +1,43 @@
+module "ddb_consume_read_capacity_alarms" {
+  source              = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarm"
+  for_each            = var.create_table && length(var.alarm_actions) > 0 ? toset(concat([""], keys(var.autoscaling_indexes))) : []
+  alarm_actions       = var.alarm_actions
+  alarm_name          = join("-", ["awsdynamodb", var.name, each.key, "ConsumedReadCapacityUnits"])
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = var.alarm_defaults.evaluation_periods
+  threshold           = ceil((each.key != "" ? var.autoscaling_indexes[each.key].read_max_capacity : var.autoscaling_read.max_capacity) * var.alarm_defaults.period * var.autoscaling_defaults.target_value / 100)
+  period              = var.alarm_defaults.period
+  unit                = "Count"
+  namespace           = "AWS/DynamoDB"
+  metric_name         = "ConsumedReadCapacityUnits"
+  statistic           = "Sum"
+  dimensions = merge({
+    TableName = var.name
+    }, each.key != "" ? {
+    GlobalSecondaryIndexName = each.key
+  } : {})
+  treat_missing_data = "ignore"
+  tags               = var.tags
+}
+
+module "ddb_consume_write_capacity_alarms" {
+  source              = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarm"
+  for_each            = var.create_table && length(var.alarm_actions) > 0 ? toset(concat([""], keys(var.autoscaling_indexes))) : []
+  alarm_actions       = var.alarm_actions
+  alarm_name          = join("-", ["awsdynamodb", var.name, each.key, "ConsumedWriteCapacityUnits"])
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = var.alarm_defaults.evaluation_periods
+  threshold           = ceil((each.key != "" ? var.autoscaling_indexes[each.key].write_max_capacity : var.autoscaling_write.max_capacity) * var.alarm_defaults.period * var.autoscaling_defaults.target_value / 100)
+  period              = var.alarm_defaults.period
+  unit                = "Count"
+  namespace           = "AWS/DynamoDB"
+  metric_name         = "ConsumedWriteCapacityUnits"
+  statistic           = "Sum"
+  dimensions = merge({
+    TableName = var.name
+    }, each.key != "" ? {
+    GlobalSecondaryIndexName = each.key
+  } : {})
+  treat_missing_data = "ignore"
+  tags               = var.tags
+}

--- a/examples/autoscaling/README.md
+++ b/examples/autoscaling/README.md
@@ -33,6 +33,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_alarm_sns_topic"></a> [alarm\_sns\_topic](#module\_alarm\_sns\_topic) | terraform-aws-modules/sns/aws |  |
 | <a name="module_disabled_dynamodb_table"></a> [disabled\_dynamodb\_table](#module\_disabled\_dynamodb\_table) | ../../ |  |
 | <a name="module_dynamodb_table"></a> [dynamodb\_table](#module\_dynamodb\_table) | ../../ |  |
 

--- a/examples/autoscaling/main.tf
+++ b/examples/autoscaling/main.tf
@@ -6,6 +6,12 @@ resource "random_pet" "this" {
   length = 2
 }
 
+module "alarm_sns_topic" {
+  source = "terraform-aws-modules/sns/aws"
+  count  = 1
+  name   = "my-alarm-sns-topic-${random_pet.this.id}"
+}
+
 module "dynamodb_table" {
   source = "../../"
 
@@ -65,6 +71,13 @@ module "dynamodb_table" {
       read_capacity      = 10
     }
   ]
+
+  alarm_actions = module.alarm_sns_topic[*].sns_topic_arn
+
+  alarm_defaults = {
+    evaluation_periods = 6
+    period             = 60
+  }
 
   tags = {
     Terraform   = "true"

--- a/variables.tf
+++ b/variables.tf
@@ -149,3 +149,15 @@ variable "autoscaling_indexes" {
   type        = map(map(string))
   default     = {}
 }
+
+variable "alarm_actions" {
+  type        = list(string)
+  default     = []
+  description = "The list of actions to execute when this alarm transitions into an ALARM state from any other state. Each action is specified as an Amazon Resource Name (ARN)."
+}
+
+variable "alarm_defaults" {
+  description = "A map with alarm settings. 'period' and 'evaluation_periods' are the only required. See example/autoscaling"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Description
Optionally add cloudwatch consume alarms when autoscaling is enabled

## Motivation and Context
Because its an usual pattern, when we have autoscaling we like to be notified if we are hitting the autoscaling max

## Breaking Changes
Its an op-in.

## How Has This Been Tested?
Updated existing examples/autoscaling
