### PR TITLE
feat: add provisions for accepting KMS key ARN for global table regions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,6 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.0.1
     hooks:
       - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ module "dynamodb_table" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.6 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.58 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.37 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.58 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.38.0 |
 
 ## Modules
 
@@ -81,7 +81,7 @@ No modules.
 | <a name="input_point_in_time_recovery_enabled"></a> [point\_in\_time\_recovery\_enabled](#input\_point\_in\_time\_recovery\_enabled) | Whether to enable point-in-time recovery | `bool` | `false` | no |
 | <a name="input_range_key"></a> [range\_key](#input\_range\_key) | The attribute to use as the range (sort) key. Must also be defined as an attribute | `string` | `null` | no |
 | <a name="input_read_capacity"></a> [read\_capacity](#input\_read\_capacity) | The number of read units for this table. If the billing\_mode is PROVISIONED, this field should be greater than 0 | `number` | `null` | no |
-| <a name="input_replica_regions"></a> [replica\_regions](#input\_replica\_regions) | Region names for creating replicas for a global DynamoDB table. | `list(string)` | `[]` | no |
+| <a name="input_replica_regions"></a> [replica\_regions](#input\_replica\_regions) | Region names for creating replicas for a global DynamoDB table. | `any` | `[]` | no |
 | <a name="input_server_side_encryption_enabled"></a> [server\_side\_encryption\_enabled](#input\_server\_side\_encryption\_enabled) | Whether or not to enable encryption at rest using an AWS managed KMS customer master key (CMK) | `bool` | `false` | no |
 | <a name="input_server_side_encryption_kms_key_arn"></a> [server\_side\_encryption\_kms\_key\_arn](#input\_server\_side\_encryption\_kms\_key\_arn) | The ARN of the CMK that should be used for the AWS KMS encryption. This attribute should only be specified if the key is different from the default DynamoDB CMK, alias/aws/dynamodb. | `string` | `null` | no |
 | <a name="input_stream_enabled"></a> [stream\_enabled](#input\_stream\_enabled) | Indicates whether Streams are to be enabled (true) or disabled (false). | `bool` | `false` | no |

--- a/examples/autoscaling/README.md
+++ b/examples/autoscaling/README.md
@@ -20,21 +20,21 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.6 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.58 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.37 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_disabled_dynamodb_table"></a> [disabled\_dynamodb\_table](#module\_disabled\_dynamodb\_table) | ../../ |  |
-| <a name="module_dynamodb_table"></a> [dynamodb\_table](#module\_dynamodb\_table) | ../../ |  |
+| <a name="module_disabled_dynamodb_table"></a> [disabled\_dynamodb\_table](#module\_disabled\_dynamodb\_table) | ../../ | n/a |
+| <a name="module_dynamodb_table"></a> [dynamodb\_table](#module\_dynamodb\_table) | ../../ | n/a |
 
 ## Resources
 

--- a/examples/autoscaling/versions.tf
+++ b/examples/autoscaling/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws    = ">= 2.58"
+    aws    = ">= 3.37"
     random = ">= 2.0"
   }
 }

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -20,21 +20,21 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.6 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.58 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.37 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_disabled_dynamodb_table"></a> [disabled\_dynamodb\_table](#module\_disabled\_dynamodb\_table) | ../../ |  |
-| <a name="module_dynamodb_table"></a> [dynamodb\_table](#module\_dynamodb\_table) | ../../ |  |
+| <a name="module_disabled_dynamodb_table"></a> [disabled\_dynamodb\_table](#module\_disabled\_dynamodb\_table) | ../../ | n/a |
+| <a name="module_dynamodb_table"></a> [dynamodb\_table](#module\_dynamodb\_table) | ../../ | n/a |
 
 ## Resources
 

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws    = ">= 2.58"
+    aws    = ">= 3.37"
     random = ">= 2.0"
   }
 }

--- a/examples/global-tables/README.md
+++ b/examples/global-tables/README.md
@@ -20,25 +20,29 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.6 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.58 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.37 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.38.0 |
+| <a name="provider_aws.euwest2"></a> [aws.euwest2](#provider\_aws.euwest2) | 3.38.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_dynamodb_table"></a> [dynamodb\_table](#module\_dynamodb\_table) | ../../ |  |
+| <a name="module_dynamodb_table"></a> [dynamodb\_table](#module\_dynamodb\_table) | ../../ | n/a |
 
 ## Resources
 
 | Name | Type |
 |------|------|
+| [aws_kms_key.primary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_kms_key.secondary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 
 ## Inputs

--- a/examples/global-tables/main.tf
+++ b/examples/global-tables/main.tf
@@ -2,9 +2,41 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+provider "aws" {
+  alias  = "euwest2"
+  region = "eu-west-2"
+}
+
+locals {
+  tags = {
+    Terraform   = "true"
+    Environment = "staging"
+  }
+}
+
+################################################################################
+# Supporting Resources
+################################################################################
+
 resource "random_pet" "this" {
   length = 2
 }
+
+resource "aws_kms_key" "primary" {
+  description = "CMK for primary region"
+  tags        = local.tags
+}
+
+resource "aws_kms_key" "secondary" {
+  provider = aws.euwest2
+
+  description = "CMK for secondary region"
+  tags        = local.tags
+}
+
+################################################################################
+# DynamoDB Global Table
+################################################################################
 
 module "dynamodb_table" {
   source = "../../"
@@ -14,6 +46,9 @@ module "dynamodb_table" {
   range_key        = "title"
   stream_enabled   = true
   stream_view_type = "NEW_AND_OLD_IMAGES"
+
+  server_side_encryption_enabled     = true
+  server_side_encryption_kms_key_arn = aws_kms_key.primary.arn
 
   attributes = [
     {
@@ -40,12 +75,10 @@ module "dynamodb_table" {
     }
   ]
 
-  replica_regions = [
-    "eu-west-2"
-  ]
+  replica_regions = [{
+    region_name = "eu-west-2"
+    kms_key_arn = aws_kms_key.secondary.arn
+  }]
 
-  tags = {
-    Terraform   = "true"
-    Environment = "staging"
-  }
+  tags = local.tags
 }

--- a/examples/global-tables/versions.tf
+++ b/examples/global-tables/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws    = ">= 2.58"
+    aws    = ">= 3.37"
     random = ">= 2.0"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -57,7 +57,8 @@ resource "aws_dynamodb_table" "this" {
     for_each = var.replica_regions
 
     content {
-      region_name = replica.value
+      region_name = replica.value.region_name
+      kms_key_arn = lookup(replica.value, "kms_key_arn", null)
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -78,7 +78,7 @@ variable "local_secondary_indexes" {
 
 variable "replica_regions" {
   description = "Region names for creating replicas for a global DynamoDB table."
-  type        = list(string)
+  type        = any
   default     = []
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws = ">= 2.58"
+    aws = ">= 3.37"
   }
 }


### PR DESCRIPTION
## Description
- add provisions for accepting KMS key ARN for global table regions

## Motivation and Context

Closes #22 

## Breaking Changes
- sort of

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
	- tested with the global table and basic examples
