### PR TITLE
feat: Added autoscaled table resource (may cause unexpected changes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ module "dynamodb_table" {
 
 ## Notes
 
-Enabling or disabling autoscaling in this module can cause your table to be recreated. There are two separate Terraform resources used for the DynamoDB table: one is for when any autoscaling settings are used and the other when not. The following scenarios will make Terraform recreate the table:
+**Warning: enabling or disabling autoscaling can cause your table to be recreated**
+
+There are two separate Terraform resources used for the DynamoDB table: one is for when any autoscaling settings are used and the other when not. The following scenarios will make Terraform recreate the table:
 
 - Upgrading from an older version of this module with autoscaling settings enabled
 - Enabling autoscaling settings when they were previously disabled

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ No modules.
 | [aws_appautoscaling_target.index_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_target) | resource |
 | [aws_appautoscaling_target.table_read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_target) | resource |
 | [aws_appautoscaling_target.table_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_target) | resource |
+| [aws_dynamodb_table.autoscaled](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
 | [aws_dynamodb_table.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ module "dynamodb_table" {
 }
 ```
 
+## Notes
+
+Enabling or disabling autoscaling in this module can cause your table to be recreated. There are two separate Terraform resources used for the DynamoDB table: one is for when any autoscaling settings are used and the other when not. The following scenarios will make Terraform recreate the table:
+
+- Upgrading from an older version of this module with autoscaling settings enabled
+- Enabling autoscaling settings when they were previously disabled
+- Disabling autoscaling settings when they were previously enabled
+
+In these scenarios you will need to move the old `aws_dynamodb_table` resource that is being `destroyed` to the new resource that is being `created`. For example:
+
+```
+terraform state mv module.dynamodb_table.aws_dynamodb_table.this module.dynamodb_table.aws_dynamodb_table.autoscaled
+```
+
 ## Examples
 
 - [Basic example](https://github.com/terraform-aws-modules/terraform-aws-dynamodb-table/tree/master/examples/basic)

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -3,7 +3,7 @@ resource "aws_appautoscaling_target" "table_read" {
 
   max_capacity       = var.autoscaling_read["max_capacity"]
   min_capacity       = var.read_capacity
-  resource_id        = "table/${aws_dynamodb_table.this[0].name}"
+  resource_id        = "table/${aws_dynamodb_table.autoscaled[0].name}"
   scalable_dimension = "dynamodb:table:ReadCapacityUnits"
   service_namespace  = "dynamodb"
 }
@@ -33,7 +33,7 @@ resource "aws_appautoscaling_target" "table_write" {
 
   max_capacity       = var.autoscaling_write["max_capacity"]
   min_capacity       = var.write_capacity
-  resource_id        = "table/${aws_dynamodb_table.this[0].name}"
+  resource_id        = "table/${aws_dynamodb_table.autoscaled[0].name}"
   scalable_dimension = "dynamodb:table:WriteCapacityUnits"
   service_namespace  = "dynamodb"
 }
@@ -63,7 +63,7 @@ resource "aws_appautoscaling_target" "index_read" {
 
   max_capacity       = each.value["read_max_capacity"]
   min_capacity       = each.value["read_min_capacity"]
-  resource_id        = "table/${aws_dynamodb_table.this[0].name}/index/${each.key}"
+  resource_id        = "table/${aws_dynamodb_table.autoscaled[0].name}/index/${each.key}"
   scalable_dimension = "dynamodb:index:ReadCapacityUnits"
   service_namespace  = "dynamodb"
 }
@@ -93,7 +93,7 @@ resource "aws_appautoscaling_target" "index_write" {
 
   max_capacity       = each.value["write_max_capacity"]
   min_capacity       = each.value["write_min_capacity"]
-  resource_id        = "table/${aws_dynamodb_table.this[0].name}/index/${each.key}"
+  resource_id        = "table/${aws_dynamodb_table.autoscaled[0].name}/index/${each.key}"
   scalable_dimension = "dynamodb:index:WriteCapacityUnits"
   service_namespace  = "dynamodb"
 }

--- a/examples/autoscaling/README.md
+++ b/examples/autoscaling/README.md
@@ -1,6 +1,6 @@
 # DynamoDB Table autoscaling example
 
-Configuration in this directory creates AWS DynamoDB table with autoscaling.
+Configuration in this directory creates AWS DynamoDB table with autoscaling. Be sure to read [the note](../../README.md#Notes) about autoscaling settings causing the table to be recreated.
 
 ## Usage
 

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,8 @@
 locals {
-  autoscaling_enabled        = length(var.autoscaling_read) + length(var.autoscaling_write) + length(var.autoscaling_indexes) > 0 ? true : false
-  table_in_use               = local.autoscaling_enabled ? aws_dynamodb_table.autoscaled : aws_dynamodb_table.this
-  create_normal_table        = var.create_table && ! local.autoscaling_enabled ? 1 : 0
-  create_autoscaled_table    = var.create_table && local.autoscaling_enabled ? 1 : 0
+  autoscaling_enabled     = length(var.autoscaling_read) + length(var.autoscaling_write) + length(var.autoscaling_indexes) > 0 ? true : false
+  table_in_use            = local.autoscaling_enabled ? aws_dynamodb_table.autoscaled : aws_dynamodb_table.this
+  create_normal_table     = var.create_table && !local.autoscaling_enabled ? 1 : 0
+  create_autoscaled_table = var.create_table && local.autoscaling_enabled ? 1 : 0
 }
 
 resource "aws_dynamodb_table" "this" {

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,12 @@
+locals {
+  autoscaling_enabled        = length(var.autoscaling_read) + length(var.autoscaling_write) + length(var.autoscaling_indexes) > 0 ? true : false
+  table_in_use               = local.autoscaling_enabled ? aws_dynamodb_table.autoscaled : aws_dynamodb_table.this
+  create_normal_table        = var.create_table && ! local.autoscaling_enabled ? 1 : 0
+  create_autoscaled_table    = var.create_table && local.autoscaling_enabled ? 1 : 0
+}
+
 resource "aws_dynamodb_table" "this" {
-  count = var.create_table ? 1 : 0
+  count = local.create_normal_table
 
   name             = var.name
   billing_mode     = var.billing_mode
@@ -78,5 +85,92 @@ resource "aws_dynamodb_table" "this" {
     create = lookup(var.timeouts, "create", null)
     delete = lookup(var.timeouts, "delete", null)
     update = lookup(var.timeouts, "update", null)
+  }
+}
+
+resource "aws_dynamodb_table" "autoscaled" {
+  count = local.create_autoscaled_table
+
+  name             = var.name
+  billing_mode     = var.billing_mode
+  hash_key         = var.hash_key
+  range_key        = var.range_key
+  read_capacity    = var.read_capacity
+  write_capacity   = var.write_capacity
+  stream_enabled   = var.stream_enabled
+  stream_view_type = var.stream_view_type
+
+  ttl {
+    enabled        = var.ttl_enabled
+    attribute_name = var.ttl_attribute_name
+  }
+
+  point_in_time_recovery {
+    enabled = var.point_in_time_recovery_enabled
+  }
+
+  dynamic "attribute" {
+    for_each = var.attributes
+
+    content {
+      name = attribute.value.name
+      type = attribute.value.type
+    }
+  }
+
+  dynamic "local_secondary_index" {
+    for_each = var.local_secondary_indexes
+
+    content {
+      name               = local_secondary_index.value.name
+      range_key          = local_secondary_index.value.range_key
+      projection_type    = local_secondary_index.value.projection_type
+      non_key_attributes = lookup(local_secondary_index.value, "non_key_attributes", null)
+    }
+  }
+
+  dynamic "global_secondary_index" {
+    for_each = var.global_secondary_indexes
+
+    content {
+      name               = global_secondary_index.value.name
+      hash_key           = global_secondary_index.value.hash_key
+      projection_type    = global_secondary_index.value.projection_type
+      range_key          = lookup(global_secondary_index.value, "range_key", null)
+      read_capacity      = lookup(global_secondary_index.value, "read_capacity", null)
+      write_capacity     = lookup(global_secondary_index.value, "write_capacity", null)
+      non_key_attributes = lookup(global_secondary_index.value, "non_key_attributes", null)
+    }
+  }
+
+  dynamic "replica" {
+    for_each = var.replica_regions
+
+    content {
+      region_name = replica.value.region_name
+      kms_key_arn = lookup(replica.value, "kms_key_arn", null)
+    }
+  }
+
+  server_side_encryption {
+    enabled     = var.server_side_encryption_enabled
+    kms_key_arn = var.server_side_encryption_kms_key_arn
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      "Name" = format("%s", var.name)
+    },
+  )
+
+  timeouts {
+    create = lookup(var.timeouts, "create", null)
+    delete = lookup(var.timeouts, "delete", null)
+    update = lookup(var.timeouts, "update", null)
+  }
+
+  lifecycle {
+    ignore_changes = [read_capacity, write_capacity]
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,5 @@
 locals {
   autoscaling_enabled     = length(var.autoscaling_read) + length(var.autoscaling_write) + length(var.autoscaling_indexes) > 0 ? true : false
-  table_in_use            = local.autoscaling_enabled ? aws_dynamodb_table.autoscaled : aws_dynamodb_table.this
   create_normal_table     = var.create_table && !local.autoscaling_enabled ? 1 : 0
   create_autoscaled_table = var.create_table && local.autoscaling_enabled ? 1 : 0
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,19 +1,19 @@
 output "dynamodb_table_arn" {
   description = "ARN of the DynamoDB table"
-  value       = element(concat(aws_dynamodb_table.this.*.arn, [""]), 0)
+  value       = element(concat(local.table_in_use.*.arn, [""]), 0)
 }
 
 output "dynamodb_table_id" {
   description = "ID of the DynamoDB table"
-  value       = element(concat(aws_dynamodb_table.this.*.id, [""]), 0)
+  value       = element(concat(local.table_in_use.*.id, [""]), 0)
 }
 
 output "dynamodb_table_stream_arn" {
   description = "The ARN of the Table Stream. Only available when var.stream_enabled is true"
-  value       = var.stream_enabled ? concat(aws_dynamodb_table.this.*.stream_arn, [""])[0] : null
+  value       = var.stream_enabled ? concat(local.table_in_use.*.stream_arn, [""])[0] : null
 }
 
 output "dynamodb_table_stream_label" {
   description = "A timestamp, in ISO 8601 format of the Table Stream. Only available when var.stream_enabled is true"
-  value       = var.stream_enabled ? concat(aws_dynamodb_table.this.*.stream_label, [""])[0] : null
+  value       = var.stream_enabled ? concat(local.table_in_use.*.stream_label, [""])[0] : null
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "dynamodb_table_arn" {
   description = "ARN of the DynamoDB table"
-  value       = element(concat(local.table_in_use.*.arn, [""]), 0)
+  value       = try(aws_dynamodb_table.this[0].arn, aws_dynamodb_table.autoscaled[0].arn, "")
 }
 
 output "dynamodb_table_id" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,10 +10,10 @@ output "dynamodb_table_id" {
 
 output "dynamodb_table_stream_arn" {
   description = "The ARN of the Table Stream. Only available when var.stream_enabled is true"
-  value       = var.stream_enabled ? concat(local.table_in_use.*.stream_arn, [""])[0] : null
+  value       = var.stream_enabled ? try(aws_dynamodb_table.this[0].id, aws_dynamodb_table.autoscaled[0].stream_arn, "") : null
 }
 
 output "dynamodb_table_stream_label" {
   description = "A timestamp, in ISO 8601 format of the Table Stream. Only available when var.stream_enabled is true"
-  value       = var.stream_enabled ? concat(local.table_in_use.*.stream_label, [""])[0] : null
+  value       = var.stream_enabled ? try(aws_dynamodb_table.this[0].id, aws_dynamodb_table.autoscaled[0].stream_label, "") : null
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,7 +5,7 @@ output "dynamodb_table_arn" {
 
 output "dynamodb_table_id" {
   description = "ID of the DynamoDB table"
-  value       = element(concat(local.table_in_use.*.id, [""]), 0)
+  value       = try(aws_dynamodb_table.this[0].id, aws_dynamodb_table.autoscaled[0].id, "")
 }
 
 output "dynamodb_table_stream_arn" {


### PR DESCRIPTION
## Description

Resolves https://github.com/terraform-aws-modules/terraform-aws-dynamodb-table/issues/14

Do I manually update the changelog?

## Motivation and Context

Fixes an issue that causes Terraform to revert changes made by autoscaling

## Breaking Changes

Absolutely 💣  I added a note in the main README. Is it enough?

## How Has This Been Tested?

I have tested and validated these changes using one or more of the provided `examples/*` projects but I don't have a live autoscaling table to test it. Could someone test it for me? Set your source to this:

```hcl
module "dynamodb_table" {
  source = "git::https://github.com/max-rocket-internet/terraform-aws-dynamodb-table.git?ref=autoscaling_fixes"
...
```

And be sure to rename your `aws_dynamodb_table` resource as [I noted](https://github.com/max-rocket-internet/terraform-aws-dynamodb-table/blob/autoscaling_fixes/README.md#notes) 🙂

