### PR TITLE
feat: Support the table class feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+### [1.3.0](https://github.com/terraform-aws-modules/terraform-aws-dynamodb-table/compare/v1.2.2...v1.3.0) (2022-06-05)
+
+
+### Features
+
+* Support table class feature ([#48](https://github.com/terraform-aws-modules/terraform-aws-dynamodb-table/issues/52)) ([]())
+
 ### [1.2.2](https://github.com/terraform-aws-modules/terraform-aws-dynamodb-table/compare/v1.2.1...v1.2.2) (2022-01-24)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-* Support table class feature ([#48](https://github.com/terraform-aws-modules/terraform-aws-dynamodb-table/issues/52)) ([]())
+* Support table class feature ([#48](https://github.com/terraform-aws-modules/terraform-aws-dynamodb-table/issues/52)) ([f3f11eb](https://github.com/HarriLLC/terraform-aws-dynamodb-table/commit/f3f11eb68a178978178b44d8ec40fc1d7e8d80ad))
 
 ### [1.2.2](https://github.com/terraform-aws-modules/terraform-aws-dynamodb-table/compare/v1.2.1...v1.2.2) (2022-01-24)
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ No modules.
 | <a name="input_ttl_attribute_name"></a> [ttl\_attribute\_name](#input\_ttl\_attribute\_name) | The name of the table attribute to store the TTL timestamp in | `string` | `""` | no |
 | <a name="input_ttl_enabled"></a> [ttl\_enabled](#input\_ttl\_enabled) | Indicates whether ttl is enabled | `bool` | `false` | no |
 | <a name="input_write_capacity"></a> [write\_capacity](#input\_write\_capacity) | The number of write units for this table. If the billing\_mode is PROVISIONED, this field should be greater than 0 | `number` | `null` | no |
+| <a name="table_class"></a> [table\_class](#table\_class) | The storage class of the table. Valid values are STANDARD and STANDARD\_INFREQUENT\_ACCESS | `string` | `null` | no |
 
 ## Outputs
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -12,6 +12,7 @@ module "dynamodb_table" {
   name      = "my-table-${random_pet.this.id}"
   hash_key  = "id"
   range_key = "title"
+  table_class = "STANDARD"
 
   attributes = [
     {

--- a/main.tf
+++ b/main.tf
@@ -9,6 +9,7 @@ resource "aws_dynamodb_table" "this" {
   write_capacity   = var.write_capacity
   stream_enabled   = var.stream_enabled
   stream_view_type = var.stream_view_type
+  table_class      = var.table_class
 
   ttl {
     enabled        = var.ttl_enabled

--- a/variables.tf
+++ b/variables.tf
@@ -155,3 +155,9 @@ variable "autoscaling_indexes" {
   type        = map(map(string))
   default     = {}
 }
+
+variable "table_class" {
+  description = "The storage class of the table. Valid values are STANDARD and STANDARD_INFREQUENT_ACCESS"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## Description
Support the table class feature.

## Motivation and Context
AWS has introduced a new feature in dymanodb where you can select a table class for your table. If you create a new table with a specific table class, then this attribute would be specified. Therefore, using the current module if you need to provision a new table or import an existing table with that attribute set, that attribute would be set to NULL, which is prohibited. 

This PR resolve the issue reported here: https://github.com/terraform-aws-modules/terraform-aws-dynamodb-table/issues/52

## Breaking Changes
This change does not break anything.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
A table with that attribute was created to make sure all is fine. All went well.
