### PR TITLE
feat: Support configuring point_in_time_recovery on replicas

### DIFF
--- a/examples/global-tables/main.tf
+++ b/examples/global-tables/main.tf
@@ -76,9 +76,10 @@ module "dynamodb_table" {
   ]
 
   replica_regions = [{
-    region_name    = "eu-west-2"
-    kms_key_arn    = aws_kms_key.secondary.arn
-    propagate_tags = true
+    region_name            = "eu-west-2"
+    kms_key_arn            = aws_kms_key.secondary.arn
+    propagate_tags         = true
+    point_in_time_recovery = true
   }]
 
   tags = local.tags

--- a/main.tf
+++ b/main.tf
@@ -58,9 +58,10 @@ resource "aws_dynamodb_table" "this" {
     for_each = var.replica_regions
 
     content {
-      region_name    = replica.value.region_name
-      kms_key_arn    = lookup(replica.value, "kms_key_arn", null)
-      propagate_tags = lookup(replica.value, "propagate_tags", null)
+      region_name            = replica.value.region_name
+      kms_key_arn            = lookup(replica.value, "kms_key_arn", null)
+      propagate_tags         = lookup(replica.value, "propagate_tags", null)
+      point_in_time_recovery = lookup(replica.value, "point_in_time_recovery", null)
     }
   }
 
@@ -142,8 +143,10 @@ resource "aws_dynamodb_table" "autoscaled" {
     for_each = var.replica_regions
 
     content {
-      region_name = replica.value.region_name
-      kms_key_arn = lookup(replica.value, "kms_key_arn", null)
+      region_name            = replica.value.region_name
+      kms_key_arn            = lookup(replica.value, "kms_key_arn", null)
+      propagate_tags         = lookup(replica.value, "propagate_tags", null)
+      point_in_time_recovery = lookup(replica.value, "point_in_time_recovery", null)
     }
   }
 


### PR DESCRIPTION
## Description

Adds support for configuring point in time recovery on global table replicas.

## Motivation and Context

There's currently no way to enable point in time recovery on replicas when using this module.

## Breaking Changes

No

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [X] I have executed `pre-commit run -a` on my pull request
