### PR TITLE
fix: Added variable table_class in autoscaled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -95,6 +95,7 @@ resource "aws_dynamodb_table" "autoscaled" {
   write_capacity   = var.write_capacity
   stream_enabled   = var.stream_enabled
   stream_view_type = var.stream_view_type
+  table_class      = var.table_class
 
   ttl {
     enabled        = var.ttl_enabled


### PR DESCRIPTION
## Description
When enabling autoscaling on an existing table, table_class is set to null

## Motivation and Context
The table_class variable is not set in the resource `module.dynamodb_table.aws_dynamodb_table.autoscaled[0]`.

When moving the feature with the below, a drift is generated in the state
```bash
terraform state mv 'module.dynamodb_table.aws_dynamodb_table.this[0]' 'module.dynamodb_table.aws_dynamodb_table.autoscaled[0]
```
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
