### PR TITLE
refactor: Use optional attributes and object type constraints

### DIFF
--- a/examples/autoscaling/versions.tf
+++ b/examples/autoscaling/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {

--- a/examples/global-tables/versions.tf
+++ b/examples/global-tables/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {

--- a/variables.tf
+++ b/variables.tf
@@ -12,8 +12,13 @@ variable "name" {
 
 variable "attributes" {
   description = "List of nested attribute definitions. Only required for hash_key and range_key attributes. Each attribute has two properties: name - (Required) The name of the attribute, type - (Required) Attribute type, which must be a scalar type: S, N, or B for (S)tring, (N)umber or (B)inary data"
-  type        = list(map(string))
-  default     = []
+  type = list(
+    object({
+      name = string
+      type = optional(string, "S")
+    })
+  )
+  default = []
 }
 
 variable "hash_key" {
@@ -114,12 +119,12 @@ variable "tags" {
 
 variable "timeouts" {
   description = "Updated Terraform resource management timeouts"
-  type        = map(string)
-  default = {
-    create = "10m"
-    update = "60m"
-    delete = "10m"
-  }
+  type = object({
+    create = optional(string, "10m")
+    update = optional(string, "60m")
+    delete = optional(string, "10m")
+  })
+  default = {}
 }
 
 variable "autoscaling_enabled" {
@@ -130,12 +135,12 @@ variable "autoscaling_enabled" {
 
 variable "autoscaling_defaults" {
   description = "A map of default autoscaling settings"
-  type        = map(string)
-  default = {
-    scale_in_cooldown  = 0
-    scale_out_cooldown = 0
-    target_value       = 70
-  }
+  type = object({
+    scale_in_cooldown  = optional(number, 0)
+    scale_out_cooldown = optional(number, 0)
+    target_value       = optional(number, 70)
+  })
+  default = {}
 }
 
 variable "autoscaling_read" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {


### PR DESCRIPTION
This should not break backwards compatibility nor cause problems but yet increase type and access safety of objects.

There are a few other places where this might come handy, right now it has been restricted to "lose" objects with a finite set of configurations.

Possibly, it is also feasible to map and create a comprehensive list of all configurations for other objects.

Something to take into account is that this is only natively available on TF >= 1.3

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
