### PR TITLE
fix: Ignore change name at aws_appautoscaling_policy

### DIFF
--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -26,6 +26,11 @@ resource "aws_appautoscaling_policy" "table_read_policy" {
     scale_out_cooldown = lookup(var.autoscaling_read, "scale_out_cooldown", var.autoscaling_defaults["scale_out_cooldown"])
     target_value       = lookup(var.autoscaling_read, "target_value", var.autoscaling_defaults["target_value"])
   }
+  lifecycle { 
+    ignore_changes = [
+      name
+    ]
+  }
 }
 
 resource "aws_appautoscaling_target" "table_write" {
@@ -55,6 +60,11 @@ resource "aws_appautoscaling_policy" "table_write_policy" {
     scale_in_cooldown  = lookup(var.autoscaling_write, "scale_in_cooldown", var.autoscaling_defaults["scale_in_cooldown"])
     scale_out_cooldown = lookup(var.autoscaling_write, "scale_out_cooldown", var.autoscaling_defaults["scale_out_cooldown"])
     target_value       = lookup(var.autoscaling_write, "target_value", var.autoscaling_defaults["target_value"])
+  }
+  lifecycle { 
+    ignore_changes = [
+      name
+    ]
   }
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add lifecycle `ignore_changes` to `aws_appautoscaling_policy.table_read_policy` and `aws_appautoscaling_policy.table_write_policy`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#79 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No, no problem

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
