### PR TITLE
docs: Mention ignore_changes_global_secondary_index can cause table to be recreated

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ is an [open issue for this on the AWS Provider](https://github.com/hashicorp/ter
 the `ignore_changes_global_secondary_index` setting however, using this setting means that any changes to GSIs will be ignored by Terraform and will
 hence have to be applied manually (or via some other automation).
 
+**NOTE**: Setting `ignore_changes_global_secondary_index` after the table is already created causes your table to be recreated. In this case, you will
+need to move the old `aws_dynamodb_table` resource that is being `destroyed` to the new resource that is being `created`. For example:
+
+```
+terraform state mv module.dynamodb_table.aws_dynamodb_table.autoscaled module.dynamodb_table.aws_dynamodb_table.autoscaled_ignore_gsi
+```
+
 ## Module wrappers
 
 Users of this Terraform module can create multiple similar resources by using [`for_each` meta-argument within `module` block](https://www.terraform.io/language/meta-arguments/for_each) which became available in Terraform 0.13.


### PR DESCRIPTION
## Description
Add a warning to the docs that setting `ignore_changes_global_secondary_index` after table is already created will cause the table to be recreated, and provide a migration path that doesn't result in data loss, similar to how was documented for enabling autoscaling for pre-existing table.

Closes #82 

## Motivation and Context
I feel that it's important to document cases where the resources maintained by the modules cause those resources to be recreated, as that can often come as a surprise and be only visible when reviewing the `terraform plan` output.

## Breaking Changes
No

## How Has This Been Tested?
N/A