### PR TITLE
fix: Allow `on_demand_throughput` optional values and disabling of table TTL 

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ Users of Terragrunt can achieve similar results by using modules provided in the
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.72.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.75.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.72.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.75.1 |
 
 ## Modules
 

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.72.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.75.1 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.72.1"
+      version = ">= 5.75.1"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/global-tables/README.md
+++ b/examples/global-tables/README.md
@@ -20,15 +20,15 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.72.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.75.1 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.72.1 |
-| <a name="provider_aws.euwest2"></a> [aws.euwest2](#provider\_aws.euwest2) | >= 5.72.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.75.1 |
+| <a name="provider_aws.euwest2"></a> [aws.euwest2](#provider\_aws.euwest2) | >= 5.75.1 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules

--- a/examples/global-tables/versions.tf
+++ b/examples/global-tables/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.72.1"
+      version = ">= 5.75.1"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/s3-import/README.md
+++ b/examples/s3-import/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.72.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.75.1 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers

--- a/examples/s3-import/versions.tf
+++ b/examples/s3-import/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.72.1"
+      version = ">= 5.75.1"
     }
     random = {
       source  = "hashicorp/random"

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.72.1"
+      version = ">= 5.75.1"
     }
   }
 }

--- a/wrappers/versions.tf
+++ b/wrappers/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.72.1"
+      version = ">= 5.75.1"
     }
   }
 }


### PR DESCRIPTION
## Description

Bumping provider version to include some provider bugfixes:
- Allow table TTL to be disabled by allowing `ttl[0].attribute_name` to be set when `ttl[0].enabled` is false
- Fix validation error when optional attribute in `on_demand_throughput` is excluded (this bug resulted in both `max_read_request_units` and `max_write_request_units` being required to be set when both are optional)

## Motivation and Context
- https://github.com/hashicorp/terraform-provider-aws/issues/40046
- https://github.com/hashicorp/terraform-provider-aws/issues/39784

## Breaking Changes
No. 

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
