### PR TITLE
update import_table

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -90,7 +90,7 @@ resource "aws_dynamodb_table" "this" {
   }
 
   dynamic "import_table" {
-    for_each = length(var.import_table) > 0 ? [var.import_table] : []
+    for_each = var.import_table != null ? [var.import_table] : []
 
     content {
       input_format           = import_table.value.input_format


### PR DESCRIPTION
Improve condition for import table functionality to have table creation with or without import

## Description
This pull request improves the conditional logic for handling the import_table variable in the aws_dynamodb_table resource definition. Specifically, it replaces a call to length(var.import_table) with a safer check that evaluates var.import_table != null before attempting to iterate or operate on it.

## Motivation and Context
The original implementation assumed that import_table would always be a list or object with a length property. However, when the variable is null (as is the case when the user conditionally disables import functionality), Terraform throws an error because length() cannot be called on a null value.

This change allows users to define DynamoDB tables with or without import settings, improving flexibility and robustness. It avoids runtime errors when import_table is null by ensuring the conditional check is safe and compatible with Terraform's type system.

## Breaking Changes
No, this change is backward-compatible. It simply adds a null check to prevent runtime errors. Existing configurations that do not use import_table will now work correctly without requiring dummy values.

## How Has This Been Tested?
I have updated my Terraform configuration to conditionally pass the import_table input to the module only when the import_dynamodb flag is set to true. This allows the same module block to be reused for multiple DynamoDB tables — some that require importing data from S3 and others that do not.
