### PR TITLE
feat: Add support for deletion protection functionality to table repl…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.99.4
+    rev: v1.100.0
     hooks:
       - id: terraform_fmt
       - id: terraform_wrapper_module_for_each
@@ -24,7 +24,7 @@ repos:
           - '--args=--only=terraform_workspace_remote'
       - id: terraform_validate
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ Users of Terragrunt can achieve similar results by using modules provided in the
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.9 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.3 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.9 |
 
 ## Modules
 

--- a/examples/autoscaling/README.md
+++ b/examples/autoscaling/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.9 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers

--- a/examples/autoscaling/versions.tf
+++ b/examples/autoscaling/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.3"
+      version = ">= 6.9"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.9 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.3"
+      version = ">= 6.9"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/global-tables/README.md
+++ b/examples/global-tables/README.md
@@ -20,15 +20,15 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.9 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.3 |
-| <a name="provider_aws.euwest2"></a> [aws.euwest2](#provider\_aws.euwest2) | >= 6.3 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.9 |
+| <a name="provider_aws.euwest2"></a> [aws.euwest2](#provider\_aws.euwest2) | >= 6.9 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules

--- a/examples/global-tables/main.tf
+++ b/examples/global-tables/main.tf
@@ -76,10 +76,11 @@ module "dynamodb_table" {
   ]
 
   replica_regions = [{
-    region_name            = "eu-west-2"
-    kms_key_arn            = aws_kms_key.secondary.arn
-    propagate_tags         = true
-    point_in_time_recovery = true
+    region_name                 = "eu-west-2"
+    kms_key_arn                 = aws_kms_key.secondary.arn
+    propagate_tags              = true
+    point_in_time_recovery      = true
+    deletion_protection_enabled = false
   }]
 
   tags = local.tags

--- a/examples/global-tables/versions.tf
+++ b/examples/global-tables/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.3"
+      version = ">= 6.9"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/s3-import/README.md
+++ b/examples/s3-import/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.9 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers

--- a/examples/s3-import/versions.tf
+++ b/examples/s3-import/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.3"
+      version = ">= 6.9"
     }
     random = {
       source  = "hashicorp/random"

--- a/main.tf
+++ b/main.tf
@@ -78,11 +78,12 @@ resource "aws_dynamodb_table" "this" {
     for_each = var.replica_regions
 
     content {
-      region_name            = replica.value.region_name
-      kms_key_arn            = lookup(replica.value, "kms_key_arn", null)
-      propagate_tags         = lookup(replica.value, "propagate_tags", null)
-      point_in_time_recovery = lookup(replica.value, "point_in_time_recovery", null)
-      consistency_mode       = try(replica.value.consistency_mode, null)
+      region_name                 = replica.value.region_name
+      kms_key_arn                 = lookup(replica.value, "kms_key_arn", null)
+      propagate_tags              = lookup(replica.value, "propagate_tags", null)
+      point_in_time_recovery      = lookup(replica.value, "point_in_time_recovery", null)
+      deletion_protection_enabled = lookup(replica.value, "deletion_protection_enabled", null)
+      consistency_mode            = try(replica.value.consistency_mode, null)
     }
   }
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.3"
+      version = ">= 6.9"
     }
   }
 }

--- a/wrappers/versions.tf
+++ b/wrappers/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.3"
+      version = ">= 6.9"
     }
   }
 }


### PR DESCRIPTION
## Description
This PR adds support for deletion protection functionality to the table replicas configuration through a new `deletion_protection_enabled` argument in the `aws_dynamodb_table` resource block, replica configuation. This feature allows users to enable AWS's built-in deletion protection safeguard for table replicas helping prevent accidental or unauthorized deletion of critical infrastructure.

https://github.com/hashicorp/terraform-provider-aws/pull/43240

## Motivation and Context

This feature was recently introduced in the Terraform AWS Provider, allowing users to enable deletion protection on DynamoDB table replicas. Adding support for this new argument ensures that our module stays up to date with the latest capabilities provided by the AWS provider and allows users to take advantage of built-in safeguards to protect critical infrastructure.

This feature was added in terraform-provider-aws [v6.9.0](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v6.9.0),  so a provider upgrade in our module must take place.


## Breaking Changes
None. This is a backward-compatible addition. The new `deletion_protection_enabled` argument defaults to false, preserving existing behavior for current module users.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
