### PR TITLE
fix: Add dependencies for autoscaled DynamoDB tables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -327,6 +327,11 @@ resource "aws_dynamodb_table" "autoscaled" {
   lifecycle {
     ignore_changes = [read_capacity, write_capacity]
   }
+
+  depends_on = [
+    aws_appautoscaling_target.table_read,
+    aws_appautoscaling_target.table_write,
+  ]
 }
 
 resource "aws_dynamodb_table" "autoscaled_gsi_ignore" {
@@ -425,6 +430,11 @@ resource "aws_dynamodb_table" "autoscaled_gsi_ignore" {
   lifecycle {
     ignore_changes = [global_secondary_index, read_capacity, write_capacity]
   }
+
+  depends_on = [
+    aws_appautoscaling_target.table_read,
+    aws_appautoscaling_target.table_write,
+  ]
 }
 
 resource "aws_dynamodb_resource_policy" "this" {


### PR DESCRIPTION
## Description
Added necessary dependencies to support autoscaled DynamoDB tables.

## Motivation and Context
This change is required to enable autoscaling functionality for DynamoDB tables, improving performance and resource management.

- Resolves #109 

## Breaking Changes
No breaking changes introduced.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ ] I have executed `pre-commit run -a` on my pull request

